### PR TITLE
Restructure nesting of labels

### DIFF
--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -201,11 +201,14 @@ GfxrVulkanCommandHierarchyCreator::GfxrVulkanCommandHierarchyCreator(
 GfxrVulkanCommandHierarchyCreator::~GfxrVulkanCommandHierarchyCreator() {}
 
 //--------------------------------------------------------------------------------------------------
-uint64_t GfxrVulkanCommandHierarchyCreator::GetActiveParent(uint64_t default_parent) const
+void GfxrVulkanCommandHierarchyCreator::AddChildToActiveParent(uint64_t child_node_index,
+                                                               uint64_t default_parent)
 {
-    return m_parsing_state.parent_node_index_stack.empty()
-               ? default_parent
-               : m_parsing_state.parent_node_index_stack.top();
+    uint64_t parent = m_parsing_state.parent_node_index_stack.empty()
+                          ? default_parent
+                          : m_parsing_state.parent_node_index_stack.top();
+
+    AddChild(CommandHierarchy::TopologyType::kAllEventTopology, parent, child_node_index);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -226,8 +229,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
             AddNode(NodeType::kGfxrVulkanBeginCommandBufferNode, vk_cmd_string_stream.str());
         m_parsing_state.command_buffer_node_index = cmd_buffer_index;
         GetArgs(vulkan_cmd_args, m_parsing_state.command_buffer_node_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_parsing_state.submit_node_index), cmd_buffer_index);
+        AddChildToActiveParent(cmd_buffer_index, m_parsing_state.submit_node_index);
         m_parsing_state.parent_node_index_stack.push(cmd_buffer_index);
     }
     else if (vulkan_cmd_name == "vkEndCommandBuffer")
@@ -244,8 +246,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
 
         GetArgs(vulkan_cmd_args, cmd_buffer_index);
 
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_parsing_state.submit_node_index), cmd_buffer_index);
+        AddChildToActiveParent(cmd_buffer_index, m_parsing_state.submit_node_index);
     }
     else if (vulkan_cmd_name.find("BeginDebugUtilsLabelEXT") != std::string::npos)
     {
@@ -253,9 +254,8 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         uint64_t begin_debug_utils_label_cmd_index =
             AddNode(NodeType::kGfxrBeginDebugUtilsLabelCommandNode, label_name.c_str());
         GetArgs(vulkan_cmd_args, begin_debug_utils_label_cmd_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_parsing_state.submit_node_index),
-                 begin_debug_utils_label_cmd_index);
+        AddChildToActiveParent(begin_debug_utils_label_cmd_index,
+                               m_parsing_state.submit_node_index);
         m_parsing_state.parent_node_index_stack.push(begin_debug_utils_label_cmd_index);
     }
     else if (vulkan_cmd_name.find("EndDebugUtilsLabelEXT") != std::string::npos)
@@ -274,8 +274,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanDrawCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
+        AddChildToActiveParent(vk_cmd_index, m_parsing_state.command_buffer_node_index);
     }
     else if (vulkan_cmd_name.find("vkCmdBeginRenderPass") != std::string::npos)
     {
@@ -288,8 +287,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanBeginRenderPassCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
+        AddChildToActiveParent(vk_cmd_index, m_parsing_state.command_buffer_node_index);
         m_parsing_state.parent_node_index_stack.push(vk_cmd_index);
     }
     else if (vulkan_cmd_name.find("vkCmdEndRenderPass") != std::string::npos)
@@ -304,8 +302,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanEndRenderPassCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
+        AddChildToActiveParent(vk_cmd_index, m_parsing_state.command_buffer_node_index);
     }
     else
     {
@@ -333,8 +330,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
 
         uint64_t vk_cmd_index = AddNode(node_type, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
+        AddChildToActiveParent(vk_cmd_index, m_parsing_state.command_buffer_node_index);
     }
 }
 

--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -201,20 +201,10 @@ GfxrVulkanCommandHierarchyCreator::GfxrVulkanCommandHierarchyCreator(
 GfxrVulkanCommandHierarchyCreator::~GfxrVulkanCommandHierarchyCreator() {}
 
 //--------------------------------------------------------------------------------------------------
-void GfxrVulkanCommandHierarchyCreator::ConditionallyAddChild(uint64_t node_index)
+uint64_t GfxrVulkanCommandHierarchyCreator::GetActiveParent(uint64_t default_parent) const
 {
-    // Check if the command node should be a child of a command buffer or debug utils/renderpass
-    // node
-    if (m_cur_parent_node_index_stack.empty())
-    {
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology, m_cur_command_buffer_node_index,
-                 node_index);
-    }
-    else
-    {
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 m_cur_parent_node_index_stack.top(), node_index);
-    }
+    return m_cur_parent_node_index_stack.empty() ? default_parent
+                                                 : m_cur_parent_node_index_stack.top();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -235,26 +225,34 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
             AddNode(NodeType::kGfxrVulkanBeginCommandBufferNode, vk_cmd_string_stream.str());
         m_cur_command_buffer_node_index = cmd_buffer_index;
         GetArgs(vulkan_cmd_args, m_cur_command_buffer_node_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology, m_cur_submit_node_index,
-                 cmd_buffer_index);
+        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
+                 GetActiveParent(m_cur_submit_node_index), cmd_buffer_index);
+        m_cur_parent_node_index_stack.push(cmd_buffer_index);
     }
     else if (vulkan_cmd_name == "vkEndCommandBuffer")
     {
+        if (!m_cur_parent_node_index_stack.empty() &&
+            m_cur_parent_node_index_stack.top() == m_cur_command_buffer_node_index)
+        {
+            m_cur_parent_node_index_stack.pop();
+        }
+
         uint64_t cmd_buffer_index =
             AddNode(NodeType::kGfxrVulkanEndCommandBufferNode, vk_cmd_string_stream.str());
 
         GetArgs(vulkan_cmd_args, cmd_buffer_index);
-        AddChild(CommandHierarchy::TopologyType::kAllEventTopology, m_cur_command_buffer_node_index,
-                 cmd_buffer_index);
+
+        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
+                 GetActiveParent(m_cur_submit_node_index), cmd_buffer_index);
     }
     else if (vulkan_cmd_name.find("BeginDebugUtilsLabelEXT") != std::string::npos)
     {
         std::string label_name = vulkan_cmd_args["pLabelInfo"]["pLabelName"];
-
         uint64_t begin_debug_utils_label_cmd_index =
             AddNode(NodeType::kGfxrBeginDebugUtilsLabelCommandNode, label_name.c_str());
         GetArgs(vulkan_cmd_args, begin_debug_utils_label_cmd_index);
-        ConditionallyAddChild(begin_debug_utils_label_cmd_index);
+        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
+                 GetActiveParent(m_cur_submit_node_index), begin_debug_utils_label_cmd_index);
         m_cur_parent_node_index_stack.push(begin_debug_utils_label_cmd_index);
     }
     else if (vulkan_cmd_name.find("EndDebugUtilsLabelEXT") != std::string::npos)
@@ -273,7 +271,8 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanDrawCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        ConditionallyAddChild(vk_cmd_index);
+        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
+                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
     }
     else if (vulkan_cmd_name.find("vkCmdBeginRenderPass") != std::string::npos)
     {
@@ -286,20 +285,24 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanBeginRenderPassCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        ConditionallyAddChild(vk_cmd_index);
+        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
+                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
         m_cur_parent_node_index_stack.push(vk_cmd_index);
     }
     else if (vulkan_cmd_name.find("vkCmdEndRenderPass") != std::string::npos)
     {
+        if (!m_cur_parent_node_index_stack.empty() &&
+            m_command_hierarchy.GetNodeType(m_cur_parent_node_index_stack.top()) ==
+                NodeType::kGfxrVulkanBeginRenderPassCommandNode)
+        {
+            m_cur_parent_node_index_stack.pop();
+        }
+
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanEndRenderPassCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        ConditionallyAddChild(vk_cmd_index);
-        if (!m_cur_parent_node_index_stack.empty())
-        {
-            // Remove the corresponding vkCmdBeginRenderPass node from the stack
-            m_cur_parent_node_index_stack.pop();
-        }
+        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
+                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
     }
     else
     {
@@ -327,7 +330,8 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
 
         uint64_t vk_cmd_index = AddNode(node_type, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
-        ConditionallyAddChild(vk_cmd_index);
+        AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
+                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
     }
 }
 
@@ -342,12 +346,6 @@ bool GfxrVulkanCommandHierarchyCreator::ProcessVkCmds(
     {
         DiveAnnotationProcessor::VulkanCommandInfo vk_cmd_info = vkCmds[i];
         OnCommand(vk_cmd_info, draw_call_count, mutable_render_pass_draw_call_counts);
-    }
-
-    // Ensure the parent node index stack is cleared
-    while (!m_cur_parent_node_index_stack.empty())
-    {
-        m_cur_parent_node_index_stack.pop();
     }
 
     return true;
@@ -385,6 +383,7 @@ bool GfxrVulkanCommandHierarchyCreator::ProcessGfxrSubmits(const GfxrCaptureData
             }
         }
     }
+    while (!m_cur_parent_node_index_stack.empty()) m_cur_parent_node_index_stack.pop();
     return true;
 }
 

--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -203,8 +203,9 @@ GfxrVulkanCommandHierarchyCreator::~GfxrVulkanCommandHierarchyCreator() {}
 //--------------------------------------------------------------------------------------------------
 uint64_t GfxrVulkanCommandHierarchyCreator::GetActiveParent(uint64_t default_parent) const
 {
-    return m_cur_parent_node_index_stack.empty() ? default_parent
-                                                 : m_cur_parent_node_index_stack.top();
+    return m_parsing_state.parent_node_index_stack.empty()
+               ? default_parent
+               : m_parsing_state.parent_node_index_stack.top();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -223,18 +224,19 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         vk_cmd_string_stream << ", Draw Call Count: " << draw_call_count;
         uint64_t cmd_buffer_index =
             AddNode(NodeType::kGfxrVulkanBeginCommandBufferNode, vk_cmd_string_stream.str());
-        m_cur_command_buffer_node_index = cmd_buffer_index;
-        GetArgs(vulkan_cmd_args, m_cur_command_buffer_node_index);
+        m_parsing_state.command_buffer_node_index = cmd_buffer_index;
+        GetArgs(vulkan_cmd_args, m_parsing_state.command_buffer_node_index);
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_cur_submit_node_index), cmd_buffer_index);
-        m_cur_parent_node_index_stack.push(cmd_buffer_index);
+                 GetActiveParent(m_parsing_state.submit_node_index), cmd_buffer_index);
+        m_parsing_state.parent_node_index_stack.push(cmd_buffer_index);
     }
     else if (vulkan_cmd_name == "vkEndCommandBuffer")
     {
-        if (!m_cur_parent_node_index_stack.empty() &&
-            (m_cur_parent_node_index_stack.top() == m_cur_command_buffer_node_index))
+        if (!m_parsing_state.parent_node_index_stack.empty() &&
+            (m_parsing_state.parent_node_index_stack.top() ==
+             m_parsing_state.command_buffer_node_index))
         {
-            m_cur_parent_node_index_stack.pop();
+            m_parsing_state.parent_node_index_stack.pop();
         }
 
         uint64_t cmd_buffer_index =
@@ -243,7 +245,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         GetArgs(vulkan_cmd_args, cmd_buffer_index);
 
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_cur_submit_node_index), cmd_buffer_index);
+                 GetActiveParent(m_parsing_state.submit_node_index), cmd_buffer_index);
     }
     else if (vulkan_cmd_name.find("BeginDebugUtilsLabelEXT") != std::string::npos)
     {
@@ -252,17 +254,18 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
             AddNode(NodeType::kGfxrBeginDebugUtilsLabelCommandNode, label_name.c_str());
         GetArgs(vulkan_cmd_args, begin_debug_utils_label_cmd_index);
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_cur_submit_node_index), begin_debug_utils_label_cmd_index);
-        m_cur_parent_node_index_stack.push(begin_debug_utils_label_cmd_index);
+                 GetActiveParent(m_parsing_state.submit_node_index),
+                 begin_debug_utils_label_cmd_index);
+        m_parsing_state.parent_node_index_stack.push(begin_debug_utils_label_cmd_index);
     }
     else if (vulkan_cmd_name.find("EndDebugUtilsLabelEXT") != std::string::npos)
     {
-        if (!m_cur_parent_node_index_stack.empty() &&
-            m_command_hierarchy.GetNodeType(m_cur_parent_node_index_stack.top()) ==
+        if (!m_parsing_state.parent_node_index_stack.empty() &&
+            m_command_hierarchy.GetNodeType(m_parsing_state.parent_node_index_stack.top()) ==
                 NodeType::kGfxrBeginDebugUtilsLabelCommandNode)
         {
             // Remove the corresponding begin debug utils node from the stack
-            m_cur_parent_node_index_stack.pop();
+            m_parsing_state.parent_node_index_stack.pop();
         }
     }
     else if (vulkan_cmd_name.find("vkCmdDraw") != std::string::npos ||
@@ -272,7 +275,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
             AddNode(NodeType::kGfxrVulkanDrawCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
+                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
     }
     else if (vulkan_cmd_name.find("vkCmdBeginRenderPass") != std::string::npos)
     {
@@ -286,23 +289,23 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
             AddNode(NodeType::kGfxrVulkanBeginRenderPassCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
-        m_cur_parent_node_index_stack.push(vk_cmd_index);
+                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
+        m_parsing_state.parent_node_index_stack.push(vk_cmd_index);
     }
     else if (vulkan_cmd_name.find("vkCmdEndRenderPass") != std::string::npos)
     {
-        if (!m_cur_parent_node_index_stack.empty() &&
-            m_command_hierarchy.GetNodeType(m_cur_parent_node_index_stack.top()) ==
+        if (!m_parsing_state.parent_node_index_stack.empty() &&
+            m_command_hierarchy.GetNodeType(m_parsing_state.parent_node_index_stack.top()) ==
                 NodeType::kGfxrVulkanBeginRenderPassCommandNode)
         {
-            m_cur_parent_node_index_stack.pop();
+            m_parsing_state.parent_node_index_stack.pop();
         }
 
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanEndRenderPassCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
+                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
     }
     else
     {
@@ -331,7 +334,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
         uint64_t vk_cmd_index = AddNode(node_type, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
-                 GetActiveParent(m_cur_command_buffer_node_index), vk_cmd_index);
+                 GetActiveParent(m_parsing_state.command_buffer_node_index), vk_cmd_index);
     }
 }
 
@@ -355,9 +358,7 @@ bool GfxrVulkanCommandHierarchyCreator::ProcessVkCmds(
 bool GfxrVulkanCommandHierarchyCreator::ProcessGfxrSubmits(const GfxrCaptureData& capture_data)
 {
     // Reset state at the beginning of processing to guarantee a clean slate
-    m_cur_parent_node_index_stack = {};
-    m_cur_submit_node_index = 0;
-    m_cur_command_buffer_node_index = 0;
+    m_parsing_state.Reset();
 
     // Add frame node
     uint64_t frame_root_node_index = AddNode(NodeType::kGfxrRootFrameNode, "Frame");
@@ -388,6 +389,9 @@ bool GfxrVulkanCommandHierarchyCreator::ProcessGfxrSubmits(const GfxrCaptureData
             }
         }
     }
+
+    // Reset state at the end of processing to guarantee a clean slate
+    m_parsing_state.Reset();
     return true;
 }
 
@@ -563,7 +567,7 @@ void GfxrVulkanCommandHierarchyCreator::OnGfxrSubmit(
 
     // Add submit node to the other topologies as children to the root node
     AddChild(CommandHierarchy::kAllEventTopology, Topology::kRootNodeIndex, submit_node_index);
-    m_cur_submit_node_index = submit_node_index;
+    m_parsing_state.submit_node_index = submit_node_index;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -232,7 +232,7 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
     else if (vulkan_cmd_name == "vkEndCommandBuffer")
     {
         if (!m_cur_parent_node_index_stack.empty() &&
-            m_cur_parent_node_index_stack.top() == m_cur_command_buffer_node_index)
+            (m_cur_parent_node_index_stack.top() == m_cur_command_buffer_node_index))
         {
             m_cur_parent_node_index_stack.pop();
         }

--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -354,6 +354,11 @@ bool GfxrVulkanCommandHierarchyCreator::ProcessVkCmds(
 //--------------------------------------------------------------------------------------------------
 bool GfxrVulkanCommandHierarchyCreator::ProcessGfxrSubmits(const GfxrCaptureData& capture_data)
 {
+    // Reset state at the beginning of processing to guarantee a clean slate
+    m_cur_parent_node_index_stack = {};
+    m_cur_submit_node_index = 0;
+    m_cur_command_buffer_node_index = 0;
+
     // Add frame node
     uint64_t frame_root_node_index = AddNode(NodeType::kGfxrRootFrameNode, "Frame");
     AddChild(CommandHierarchy::kAllEventTopology, Topology::kRootNodeIndex, frame_root_node_index);
@@ -383,7 +388,6 @@ bool GfxrVulkanCommandHierarchyCreator::ProcessGfxrSubmits(const GfxrCaptureData
             }
         }
     }
-    while (!m_cur_parent_node_index_stack.empty()) m_cur_parent_node_index_stack.pop();
     return true;
 }
 

--- a/dive_core/gfxr_vulkan_command_hierarchy.h
+++ b/dive_core/gfxr_vulkan_command_hierarchy.h
@@ -75,7 +75,7 @@ class GfxrVulkanCommandHierarchyCreator
     // Updates m_node_children
     void AddChild(CommandHierarchy::TopologyType type, uint64_t node_index,
                   uint64_t child_node_index);
-    uint64_t GetActiveParent(uint64_t default_parent) const;
+    void AddChildToActiveParent(uint64_t child_node_index, uint64_t default_parent);
 
     struct ParsingState
     {

--- a/dive_core/gfxr_vulkan_command_hierarchy.h
+++ b/dive_core/gfxr_vulkan_command_hierarchy.h
@@ -77,9 +77,21 @@ class GfxrVulkanCommandHierarchyCreator
                   uint64_t child_node_index);
     uint64_t GetActiveParent(uint64_t default_parent) const;
 
-    uint64_t m_cur_submit_node_index = 0;
-    uint64_t m_cur_command_buffer_node_index = 0;
-    std::stack<uint64_t> m_cur_parent_node_index_stack;
+    struct ParsingState
+    {
+        uint64_t submit_node_index = 0;
+        uint64_t command_buffer_node_index = 0;
+        std::stack<uint64_t> parent_node_index_stack;
+
+        void Reset()
+        {
+            submit_node_index = 0;
+            command_buffer_node_index = 0;
+            parent_node_index_stack = {};
+        }
+    };
+
+    ParsingState m_parsing_state;
     CommandHierarchy& m_command_hierarchy;
     const GfxrCaptureData& m_capture_data;
     // This is a list of child indices per node, ie. topology info

--- a/dive_core/gfxr_vulkan_command_hierarchy.h
+++ b/dive_core/gfxr_vulkan_command_hierarchy.h
@@ -75,7 +75,7 @@ class GfxrVulkanCommandHierarchyCreator
     // Updates m_node_children
     void AddChild(CommandHierarchy::TopologyType type, uint64_t node_index,
                   uint64_t child_node_index);
-    void ConditionallyAddChild(uint64_t node_index);
+    uint64_t GetActiveParent(uint64_t default_parent) const;
 
     uint64_t m_cur_submit_node_index = 0;
     uint64_t m_cur_command_buffer_node_index = 0;


### PR DESCRIPTION
Restructures nesting of labeling to match renderdoc
**Manual Testing:**
Linux, MacOS
- Load gfxr capture, replay with renderdoc enabled, compare structure of dive tree view to that of renderdoc
