### PR TITLE
Replace Release builds in workflows with RelWithDebInfo

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - build_type: Release
+          - build_type: RelWithDebInfo
             cc: gcc-14
             cxx: g++-14
-          - build_type: Release
+          - build_type: RelWithDebInfo
             cc: clang-19
             cxx: clang++-19
     uses: ./.github/workflows/build_linux.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
     uses: ./.github/workflows/build_windows.yml
     with:
       build_type: ${{ matrix.build_type }}
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/build_mac.yml
     with:
-      build_type: Release
+      build_type: RelWithDebInfo
       restore_cache: true
       upload_cache: false
 
@@ -62,6 +62,6 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/build_android.yml
     with:
-      build_type: Release
+      build_type: RelWithDebInfo
       restore_cache: true
       upload_cache: false

--- a/.github/workflows/weekdays.yml
+++ b/.github/workflows/weekdays.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
         cc: [gcc-14, clang-19]
         include:
           - cc: gcc-14
@@ -36,7 +36,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
     uses: ./.github/workflows/build_windows.yml
     with:
       build_type: ${{ matrix.build_type }}
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
     uses: ./.github/workflows/build_mac.yml
     with:
       build_type: ${{ matrix.build_type }}
@@ -60,7 +60,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
     uses: ./.github/workflows/build_android.yml
     with:
       build_type: ${{ matrix.build_type }}


### PR DESCRIPTION
This would more accurately test the build type that we plan to release to users