### PR TITLE
[GFXR] Modify desktop replay to use gfxr_ext_decode_lib

### DIFF
--- a/third_party/gfxreconstruct/tools/replay/CMakeLists.txt
+++ b/third_party/gfxreconstruct/tools/replay/CMakeLists.txt
@@ -56,6 +56,8 @@ target_link_libraries(gfxrecon-replay
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
                           $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)
 
+target_link_libraries(gfxrecon-replay gfxr_decode_ext_lib)
+
 target_link_options(gfxrecon-replay PUBLIC "-rdynamic")
 
 if (MSVC)

--- a/third_party/gfxreconstruct/tools/replay/desktop_main.cpp
+++ b/third_party/gfxreconstruct/tools/replay/desktop_main.cpp
@@ -33,6 +33,9 @@
 #include "generated/generated_vulkan_decoder.h"
 #include "generated/generated_vulkan_replay_consumer.h"
 
+#include "gfxr_ext/decode/dive_file_processor.h"
+#include "gfxr_ext/decode/dive_vulkan_replay_consumer.h"
+
 #if ENABLE_OPENXR_SUPPORT
 #include "decode/openxr_tracked_object_info_table.h"
 #include "generated/generated_openxr_decoder.h"
@@ -145,7 +148,7 @@ int main(int argc, const char** argv)
         }
         else
         {
-            file_processor = std::make_unique<gfxrecon::decode::FileProcessor>();
+            file_processor = std::make_unique<gfxrecon::decode::DiveFileProcessor>();
         }
 
         if (!file_processor->Initialize(filename))
@@ -203,8 +206,18 @@ int main(int argc, const char** argv)
                                                  quit_after_frame,
                                                  quit_frame);
 
-            gfxrecon::decode::VulkanReplayConsumer vulkan_replay_consumer(application, vulkan_replay_options);
+            gfxrecon::decode::DiveVulkanReplayConsumer vulkan_replay_consumer(application, vulkan_replay_options);
             gfxrecon::decode::VulkanDecoder        vulkan_decoder;
+
+            if (vulkan_replay_options.loop_single_frame_count.has_value())
+            {
+                static_cast<gfxrecon::decode::DiveFileProcessor*>(file_processor.get())->SetLoopSingleFrameCount(*(vulkan_replay_options.loop_single_frame_count));
+            }
+
+            if (arg_parser.IsOptionSet(kEnableGPUTime))
+            {
+                vulkan_replay_consumer.SetEnableGPUTime(vulkan_replay_options.enable_gpu_time);
+            }
 
             if (vulkan_replay_options.capture)
             {


### PR DESCRIPTION
This could be used to improve test coverage by running faster tests on the host (instead of requiring an Android device)

![screenshot_frame_1](https://github.com/user-attachments/assets/13d6781d-1c9a-4c54-a107-31f89110d7b3)

[gfxrecon_capture_trim_trigger_20260305T112659.zip](https://github.com/user-attachments/files/25774648/gfxrecon_capture_trim_trigger_20260305T112659.zip)
