### PR TITLE
Prototype for automated UI tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,11 +149,27 @@ if(NOT ANDROID)
     # Include gtest before Abseil so we can use ABSL_BUILD_TEST_HELPERS for status_matchers
     # Ask gtest to use /MD or /MDd since it matches the CMake defaults that we use.
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    # In order to use gtest in the automated UI testing plugin, it needs to be compiled with
+    # position independent code. Given that this is a testing library, this shouldn't impact the
+    # released target.
+    # TODO: This should be GCC/Clang only
+    set(OLD_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    set(OLD_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "-fPIC")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+        endif()
+        if(NOT "${CMAKE_C_FLAGS}" MATCHES "-fPIC")
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+        endif()
+    endif()
     message(CHECK_START "Generate build files for third_party/googletest")
     list(APPEND CMAKE_MESSAGE_INDENT "  ")
     add_subdirectory(third_party/googletest)
     list(POP_BACK CMAKE_MESSAGE_INDENT)
     message(CHECK_PASS "done")
+    set(CMAKE_C_FLAGS "${OLD_CMAKE_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${OLD_CMAKE_CXX_FLAGS}")
 
     # For highly parallelized builds, performing test dicovery (running a test with --gtest_list_tests) during the build may time out.
     # The high CPU load is likely starving program execution of resources.

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
 # For each new plugin, you can add an add_subdirectory call here.
+add_subdirectory(automated_test)
 add_subdirectory(plugin_sample)
 
 list(POP_BACK CMAKE_MESSAGE_INDENT)

--- a/plugins/automated_test/CMakeLists.txt
+++ b/plugins/automated_test/CMakeLists.txt
@@ -1,0 +1,44 @@
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+find_package(Qt5 COMPONENTS Core Gui Widgets Test REQUIRED)
+
+add_library(dive_automated_test_plugin SHARED automated_test.cpp)
+
+target_link_libraries(
+    dive_automated_test_plugin
+    PRIVATE
+        Qt5::Core
+        Qt5::Gui
+        Qt5::Widgets
+        Qt5::Test
+        dive_plugin_abi_includes
+        gtest
+)
+
+target_include_directories(
+    dive_automated_test_plugin
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_BINARY_DIR}/dive_core
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+# TODO: fix sample plugin
+install(
+    TARGETS dive_automated_test_plugin
+    DESTINATION "${DIVE_PLUGINS_PARENT_DIR}"
+)

--- a/plugins/automated_test/automated_test.cpp
+++ b/plugins/automated_test/automated_test.cpp
@@ -1,0 +1,198 @@
+/*
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QDebug>
+#include <QDialog>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QObject>
+#include <QPushButton>
+#include <QTest>
+#include <QTimer>
+#include <QWidget>
+#include <filesystem>
+
+#include "dive/plugin/abi/idive_plugin.h"
+
+// To run headless, use either the minimal or offscreen QPA:
+//
+//     QT_QPA_PLATFORM=offscreen ./build/pkg/host/dive
+//
+// - minimal doesn't do font rendering
+// - offscreen uses font that's too big
+//
+// On Linux over SSH, consider using Xvfb
+//
+//     Xvfb :99 -screen 0 1024x768x24 &
+//     DISPLAY=:99 ./build/pkg/host/dive
+
+namespace Dive
+{
+namespace
+{
+
+template <typename T>
+T FindTopLevelWidget(const QString& name)
+{
+    for (QWidget* widget : QApplication::topLevelWidgets())
+    {
+        if (widget->objectName() != name)
+        {
+            continue;
+        }
+
+        return qobject_cast<T>(widget);
+    }
+    return nullptr;
+}
+
+bool TakeScreenshot(QWidget* widget, const std::filesystem::path& file)
+{
+    QPixmap pixmap(widget->size());
+    widget->render(&pixmap);
+    return pixmap.save(QString::fromStdString(file.string()));
+};
+
+// When loaded, schedules the start of a gTest run after the program has finished initialization.
+// This acts as a bridge between plugin loading and gtest execution given that we don't have access
+// to main.
+class AutomatedTestPlugin : public IDivePlugin
+{
+ public:
+    ~AutomatedTestPlugin() override = default;
+
+    std::string PluginName() const override { return "Automated Test"; }
+    std::string PluginVersion() const override { return "1.0.0"; }
+
+    bool Initialize(IDivePluginBridge& /*bridge*/) override
+    {
+        qDebug() << "AutomatedTestPlugin::Initialize";
+        auto* main_window = FindTopLevelWidget<QWidget*>("MainWindow");
+
+        // Plugin initialization is done before the main event loop starts. To ensure initialization
+        // has complete, defer starting tests until the main event loop is running.
+        // TODO: Why does qWaitForWindowActive break if I don't wait ~1000ms?
+        qDebug() << "Scheduling test runs";
+        QTimer::singleShot(1000, [] {
+            qDebug() << "Running tests!";
+            int argc = 1;
+            std::array<char*, 1> argv = {"foo"};  // TODO bad!!
+            testing::InitGoogleTest(&argc, argv.data());
+            qApp->exit(RUN_ALL_TESTS());
+        });
+
+        qDebug() << "AutomatedTestPlugin::Initialize done";
+        return true;
+    }
+
+    void Shutdown() override {}
+};
+
+TEST(DiveUiTest, CanCaptureGfxrWithTraceDialog)
+{
+    // Find the primary Dive UI window. Confusingly, MainWindow is a top-level widget (not a
+    // top-level window).
+    auto* main_window = FindTopLevelWidget<QWidget*>("MainWindow");
+    ASSERT_NE(main_window, nullptr);
+    ASSERT_TRUE(QTest::qWaitForWindowActive(main_window));
+    EXPECT_TRUE(TakeScreenshot(main_window, "main_window.png"));
+
+    // Open the Capture dialog by using the F5 keyboard shortcut
+    auto* trace_dialog = main_window->findChild<QDialog*>("TraceDialog");
+    ASSERT_NE(trace_dialog, nullptr);
+
+    QTest::keyClick(main_window, Qt::Key_F5);
+    ASSERT_TRUE(QTest::qWaitForWindowActive(trace_dialog));
+
+    // Enter in the package name in the Executable text field. Confusingly, using the package combo
+    // box doesn't work the same way.
+    auto* executable_line_edit = trace_dialog->findChild<QLineEdit*>("Executable LineEdit");
+    ASSERT_NE(executable_line_edit, nullptr);
+
+    QTest::keyClicks(executable_line_edit, "com.google.bigwheels.project_cube_xr.debug");
+    // TODO: Verify that the package is an element in the combo box.
+    // The test hogs the main thread so we need to explicitly post any events.
+    QCoreApplication::sendPostedEvents(executable_line_edit);
+
+    // Click the "Start Application" button and wait for the app to start
+    auto* start_application = trace_dialog->findChild<QPushButton*>("Start Application");
+    ASSERT_NE(start_application, nullptr);
+    ASSERT_TRUE(start_application->isEnabled());
+    ASSERT_EQ(start_application->text(), QString("&Start Application"));
+
+    // I can't seem to get QTest::mouseClick to work so just emit the click signal.
+    start_application->click();
+    ASSERT_TRUE(QTest::qWaitFor(
+        [start_application] { return start_application->text() == "&Stop Application"; }));
+
+    // Click the "Start GFXR Capture" button and wait for capture to complete
+    auto* capture_button = trace_dialog->findChild<QPushButton*>("GFXR Capture Button");
+    ASSERT_NE(capture_button, nullptr);
+    ASSERT_TRUE(capture_button->isEnabled());
+    ASSERT_EQ(capture_button->text(), QString("&Start GFXR Capture"));
+
+    // The capture and retrieve buttons are the same, just the text changes.
+    capture_button->click();
+    ASSERT_TRUE(QTest::qWaitFor(
+        [capture_button] { return capture_button->text() == "&Retrieve GFXR Capture"; }));
+
+    // Click the "Retrieve GFXR Capture" button and wait for the message box with the status.
+    // TODO QProgressDialog?
+    capture_button->click();
+    QMessageBox* message_box = nullptr;
+    ASSERT_TRUE(QTest::qWaitFor([trace_dialog, &message_box] {
+        message_box = trace_dialog->findChild<QMessageBox*>("TraceDialog MessageBox");
+        return message_box != nullptr;
+    }));
+
+    ASSERT_TRUE(message_box->text().contains("Capture successfully saved at"));
+    EXPECT_TRUE(TakeScreenshot(message_box, "message_box.png"));
+
+    message_box->close();
+    QCoreApplication::sendPostedEvents(message_box);
+
+    // After retrieving the capture, the button should revert back to "Start GFXR Capture"
+    ASSERT_TRUE(QTest::qWaitFor(
+        [capture_button] { return capture_button->text() == "&Start GFXR Capture"; }));
+    // After the capture is retrieved, it is loaded by the UI. During capturing loading, the entire
+    // UI is disabled. We have to wait for loading to complete, signified by the button becoming
+    // enabled again. Qt won't warn us if we try to click() a disabled button.
+    ASSERT_TRUE(QTest::qWaitFor([start_application] {
+        // The start and stop buttons are the same, just the text changes.
+        return start_application->isEnabled();
+    }));
+
+    // Click the "Stop Application" button and wait for the app to stop.
+    start_application->click();
+    ASSERT_TRUE(QTest::qWaitFor(
+        [start_application] { return start_application->text() == "&Start Application"; }));
+
+    // Close the capture dialog and wait for it to close.
+    trace_dialog->close();
+    QCoreApplication::sendPostedEvents(trace_dialog);
+    ASSERT_TRUE(QTest::qWaitFor([trace_dialog] { return !trace_dialog->isVisible(); }));
+}
+
+}  // namespace
+
+extern "C" DIVE_PLUGIN_EXPORT IDivePlugin* CreateDivePluginInstance()
+{
+    return new AutomatedTestPlugin();
+}
+}  // namespace Dive

--- a/ui/main.cpp
+++ b/ui/main.cpp
@@ -210,6 +210,7 @@ int main(int argc, char* argv[])
     Pm4InfoInit();
 
     QScopedPointer<MainWindow> main_window{new MainWindow(app->GetController())};
+    main_window->setObjectName("MainWindow");
 
     if (auto scenario = absl::GetFlag(FLAGS_test_scenario); !scenario.empty())
     {

--- a/ui/main_window.cpp
+++ b/ui/main_window.cpp
@@ -509,6 +509,7 @@ MainWindow::MainWindow(ApplicationController& controller) : m_controller(control
     LoadAvailableMetrics();
 
     m_trace_dig = new TraceDialog(m_controller, this);
+    m_trace_dig->setObjectName("TraceDialog");
     m_analyze_dig = new AnalyzeDialog(m_controller, m_available_metrics.get(), this);
     m_what_if_setup_dig = new WhatIfSetupDialog(this);
     m_what_if_configure_dig = new WhatIfConfigureDialog(this);

--- a/ui/trace_window.cpp
+++ b/ui/trace_window.cpp
@@ -92,10 +92,12 @@ TraceDialog::TraceDialog(ApplicationController& controller, QWidget* parent)
 
     m_button_layout = new QHBoxLayout();
     m_run_button = new QPushButton(kStart_Application, this);
+    m_run_button->setObjectName("Start Application");
     m_run_button->setEnabled(false);
     m_capture_button = new QPushButton("&Trace", this);
     m_capture_button->setEnabled(false);
     m_gfxr_capture_button = new QPushButton(kStart_Gfxr_Runtime_Capture, this);
+    m_gfxr_capture_button->setObjectName("GFXR Capture Button");
     m_gfxr_capture_button->setEnabled(false);
     m_gfxr_capture_button->hide();
 
@@ -165,6 +167,7 @@ TraceDialog::TraceDialog(ApplicationController& controller, QWidget* parent)
     m_cmd_layout = new QHBoxLayout();
     m_file_label = new QLabel("Executable:");
     m_cmd_input_box = new QLineEdit();
+    m_cmd_input_box->setObjectName("Executable LineEdit");
     m_cmd_input_box->setPlaceholderText("Input a command or select from the package list");
     m_cmd_input_box->setClearButtonEnabled(true);
     m_cmd_layout->addWidget(m_file_label);
@@ -275,6 +278,7 @@ TraceDialog::~TraceDialog()
 void TraceDialog::ShowMessage(const QString& message)
 {
     auto message_box = new QMessageBox(this);
+    message_box->setObjectName("TraceDialog MessageBox");
     message_box->setAttribute(Qt::WA_DeleteOnClose, true);
     message_box->setText(message);
     message_box->open();


### PR DESCRIPTION
UI tests can be written as gtests. This is made possible by Qt reflection and the many functions it exposes to query the object graph.

Tips for writing tests:

- Call setObjectName on things you want to find the test. These can be found with findChild
- Send key events using QTest::keyClick
- Manually process the event loop with QCoreApplication::sendPostedEvents
- Use QTest::qWaitFor when waiting for something to happen so that the main event loop is still processed.
- If something isn't working, add more asserts on state. E.g. Qt won't warn if you try to click a button that is disabled; either assert that the button is enabled for qWaitFor it to become enabled.
- I can't seem to get QTest::mouseClick to work so prefer keyboard navigaion, keyboard shortcuts, or directly emitting signals.

The tests are compiled into a plugin which is loaded into the Dive UI process. The plugin runs the tests after the UI has initialized

Test output is printed to stdout/stderr. In the future, I think it makes sense to write this to a file as well.