### PR TITLE
Write valid modified block data

### DIFF
--- a/gfxr_ext/decode/dive_block_data.cpp
+++ b/gfxr_ext/decode/dive_block_data.cpp
@@ -83,7 +83,7 @@ bool WriterBlockVisitor::Visit(const DiveModificationBlock& block)
         GFXRECON_LOG_ERROR("WriterBlockVisitor encountered empty modification block");
         return false;
     }
-    if (!util::platform::FileWrite(block.blob_ptr_.get(), block.blob_ptr_->size(), new_file_ptr_))
+    if (!util::platform::FileWrite(block.blob_ptr_->data(), block.blob_ptr_->size(), new_file_ptr_))
     {
         GFXRECON_LOG_ERROR("Writing modified block, could not write to new file");
         return false;


### PR DESCRIPTION
Replay was unable to load a capture file that had modifications added to it. This is because the `std::vector<char>` object internal state was being written, not the block contents. The compiler didn't catch this because `block.blob_ptr_.get()` is `std::vector<char>*`; this implicitly casts to the `void*` that `FileWrite` wants.

Fix this by writing `std::vector::data()` which contains the block bytes.