### PR TITLE
Remove unused forward declaration

### DIFF
--- a/gfxr_ext/decode/dive_annotation_processor.h
+++ b/gfxr_ext/decode/dive_annotation_processor.h
@@ -21,8 +21,6 @@
 #include "util/defines.h"
 #include "util/platform.h"
 
-struct ApiCallInfo;
-
 // The DiveAnnotationProcessor is used by the VulkanExportDiveConsumer on each WriteBlockEnd call
 // made when processing the vulkan commands. WriteBlockEnd is called passing the function data
 // (name, command buffer index, args) and then DiveAnnotationProcessor converts the data to


### PR DESCRIPTION
This was throwing my VSCode extensions for a loop: it couldn't find the correct header to include for ApiCallInfo.

(Additionally, if it was necessary, the actual definition is in the `gfxrecon::decode` namespace.)