### PR TITLE
Protects internal data to avoid race condition at gpu_time

### DIFF
--- a/gpu_time/CMakeLists.txt
+++ b/gpu_time/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(
     frame_boundary_detector.cpp
     frame_boundary_detector.h
 )
-target_link_libraries(gpu_time PUBLIC Vulkan::Headers)
+target_link_libraries(gpu_time PUBLIC Vulkan::Headers absl::synchronization)
 
 # This is to fix build on Linux
 set_property(TARGET gpu_time PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -48,6 +48,27 @@ if(NOT ANDROID)
         PRIVATE gpu_time gtest gtest_main gmock
     )
     gtest_discover_tests(frame_boundary_detector_test)
+
+    # Search for the benchmark library without forcing it as a requirement
+    find_package(benchmark QUIET)
+
+    if(benchmark_FOUND)
+        # Create the benchmark target but exclude it from the default build
+        add_executable(
+            gpu_time_benchmark
+            EXCLUDE_FROM_ALL
+            gpu_time_benchmark.cpp
+        )
+        target_link_libraries(
+            gpu_time_benchmark
+            PRIVATE gpu_time benchmark::benchmark benchmark::benchmark_main
+        )
+    else()
+        message(
+            STATUS
+            "Google Benchmark not found; skipping gpu_time_benchmark target."
+        )
+    endif()
 endif()
 
 list(POP_BACK CMAKE_MESSAGE_INDENT)

--- a/gpu_time/gpu_time.cpp
+++ b/gpu_time/gpu_time.cpp
@@ -279,7 +279,8 @@ size_t GPUTime::FrameMetrics::GetCmdRenderPassCount(size_t index) const
 
 std::string GPUTime::GetStatsString() const
 {
-    const Stats& stats = GetFrameTimeStats();
+    absl::MutexLock lock(&m_mutex);
+    const Stats stats = m_metrics.GetFrameTimeStats();
     std::stringstream ss;
     ss << "FrameMetrics:\n";
 
@@ -295,14 +296,14 @@ std::string GPUTime::GetStatsString() const
     size_t cmd_count = m_metrics.GetFrameCmdCount();
     for (size_t i = 0; i < cmd_count; ++i)
     {
-        const Stats& cmd_stats = GetFrameCmdTimeStats(i);
+        const Stats cmd_stats = m_metrics.GetFrameCmdTimeStats(i);
         ss << "\tCommandBuffer" << i << ": \n";
         PopulateStatsString(ss, cmd_stats, 1);
 
-        size_t renderpass_count = GetCmdRenderPassCount(i);
+        size_t renderpass_count = m_metrics.GetCmdRenderPassCount(i);
         for (size_t j = 0; j < renderpass_count; ++j)
         {
-            const Stats& renderpass_stats = GetFrameRenderPassTimeStats(renderpass_index);
+            const Stats renderpass_stats = m_metrics.GetFrameRenderPassTimeStats(renderpass_index);
             ss << "\t\tRenderPass" << renderpass_index << ": \n";
             PopulateStatsString(ss, renderpass_stats, 2);
             renderpass_index++;
@@ -316,7 +317,8 @@ std::string GPUTime::GetStatsString() const
 
 std::string GPUTime::GetStatsCSVString() const
 {
-    const Stats& stats = GetFrameTimeStats();
+    absl::MutexLock lock(&m_mutex);
+    const Stats stats = m_metrics.GetFrameTimeStats();
     std::stringstream ss;
 
     ss << std::fixed << std::setprecision(3) << "Frame," << std::to_string(m_frame_index) << ","
@@ -326,14 +328,14 @@ std::string GPUTime::GetStatsCSVString() const
     size_t cmd_count = m_metrics.GetFrameCmdCount();
     for (size_t cmd_index = 0; cmd_index < cmd_count; ++cmd_index)
     {
-        const Stats& cmd_stats = GetFrameCmdTimeStats(cmd_index);
+        const Stats cmd_stats = m_metrics.GetFrameCmdTimeStats(cmd_index);
         ss << std::fixed << std::setprecision(3) << "CommandBuffer," << std::to_string(cmd_index)
            << "," << cmd_stats.average << "," << cmd_stats.median << "\n";
 
-        size_t rp_count = GetCmdRenderPassCount(cmd_index);
+        size_t rp_count = m_metrics.GetCmdRenderPassCount(cmd_index);
         for (size_t j = 0; j < rp_count; ++j)
         {
-            const Stats& rp_stats = GetFrameRenderPassTimeStats(rp_index);
+            const Stats rp_stats = m_metrics.GetFrameRenderPassTimeStats(rp_index);
             ss << std::fixed << std::setprecision(3) << "RenderPass," << std::to_string(rp_index)
                << "," << rp_stats.average << "," << rp_stats.median << "\n";
             rp_index++;
@@ -351,6 +353,7 @@ GPUTime::GpuTimeStatus GPUTime::OnCreateDevice(VkDevice device,
 {
     if (device == VK_NULL_HANDLE)
     {
+        absl::MutexLock lock(&m_mutex);
         m_valid_frame = false;
         return GPUTime::GpuTimeStatus{"Need to pass in a valid device!", false};
     }
@@ -368,6 +371,7 @@ GPUTime::GpuTimeStatus GPUTime::OnCreateDevice(VkDevice device,
     VkResult result = pfn_create_query_pool(m_device, &queryPoolInfo, m_allocator, &m_query_pool);
     if (result != VK_SUCCESS)
     {
+        absl::MutexLock lock(&m_mutex);
         m_valid_frame = false;
         return GPUTime::GpuTimeStatus{
             "vkCreateQueryPool failed with VkResult: " + std::to_string(static_cast<int>(result)),
@@ -388,6 +392,7 @@ GPUTime::GpuTimeStatus GPUTime::OnDestroyDevice(VkDevice device,
 
     if ((m_device != VK_NULL_HANDLE) && (m_query_pool != VK_NULL_HANDLE))
     {
+        absl::MutexLock lock(&m_mutex);
         if (m_queues.empty())
         {
             return GPUTime::GpuTimeStatus{"vk queue is empty!"};
@@ -415,6 +420,7 @@ GPUTime::GpuTimeStatus GPUTime::OnDestroyCommandPool(VkCommandPool command_pool)
         return GPUTime::GpuTimeStatus();
     }
 
+    absl::MutexLock lock(&m_mutex);
     auto it = m_cmds.begin();
     while (it != m_cmds.end())
     {
@@ -447,6 +453,7 @@ GPUTime::GpuTimeStatus GPUTime::OnAllocateCommandBuffers(
         return GPUTime::GpuTimeStatus();
     }
 
+    absl::MutexLock lock(&m_mutex);
     for (uint32_t i = 0; i < allocate_info_ptr->commandBufferCount; ++i)
     {
         if (m_cmds.find(command_buffers_ptr[i]) != m_cmds.end())
@@ -482,6 +489,7 @@ GPUTime::GpuTimeStatus GPUTime::OnFreeCommandBuffers(uint32_t command_buffer_cou
 {
     m_boundary_detector.OnFreeCommandBuffers(command_buffer_count, command_buffers_ptr);
 
+    absl::MutexLock lock(&m_mutex);
     for (uint32_t i = 0; i < command_buffer_count; ++i)
     {
         if (m_cmds.find(command_buffers_ptr[i]) == m_cmds.end())
@@ -501,6 +509,7 @@ GPUTime::GpuTimeStatus GPUTime::OnResetCommandBuffer(VkCommandBuffer command_buf
 {
     m_boundary_detector.OnResetCommandBuffer(command_buffer);
 
+    absl::MutexLock lock(&m_mutex);
     if (m_cmds.find(command_buffer) == m_cmds.end())
     {
         // The cache doesn't contain secondary command buffers
@@ -514,6 +523,7 @@ GPUTime::GpuTimeStatus GPUTime::OnResetCommandPool(VkCommandPool command_pool)
 {
     m_boundary_detector.OnResetCommandPool(command_pool);
 
+    absl::MutexLock lock(&m_mutex);
     for (auto& cmd : m_cmds)
     {
         if (cmd.second.pool == command_pool)
@@ -533,6 +543,7 @@ GPUTime::GpuTimeStatus GPUTime::OnBeginCommandBuffer(
         return GPUTime::GpuTimeStatus();
     }
 
+    absl::MutexLock lock(&m_mutex);
     auto iter = m_cmds.find(command_buffer);
     if (iter == m_cmds.end())
     {
@@ -567,6 +578,7 @@ GPUTime::GpuTimeStatus GPUTime::OnEndCommandBuffer(VkCommandBuffer command_buffe
         return GPUTime::GpuTimeStatus();
     }
 
+    absl::MutexLock lock(&m_mutex);
     auto iter = m_cmds.find(command_buffer);
     if (iter == m_cmds.end())
     {
@@ -582,12 +594,8 @@ GPUTime::GpuTimeStatus GPUTime::OnEndCommandBuffer(VkCommandBuffer command_buffe
 }
 
 GPUTime::GpuTimeStatus GPUTime::OnFrameBoundary(
-    PFN_vkDeviceWaitIdle pfn_device_wait_idle, PFN_vkResetQueryPool pfn_reset_query_pool,
-    PFN_vkGetQueryPoolResults pfn_get_query_pool_results)
+    PFN_vkResetQueryPool pfn_reset_query_pool, PFN_vkGetQueryPoolResults pfn_get_query_pool_results)
 {
-    //  force sync to make sure the gpu is done with this frame
-    pfn_device_wait_idle(m_device);
-
     GPUTime::GpuTimeStatus update_status;
     if (m_valid_frame)
     {
@@ -855,6 +863,10 @@ GPUTime::SubmitStatus GPUTime::OnQueueSubmit(uint32_t submit_count, const VkSubm
 
     bool is_frame_boundary = m_boundary_detector.ContainsFrameBoundary(submit_count, submits_ptr);
 
+    // Take the lock at the beginning of the function to treat the submit
+    // and subsequent frame boundary logic as a single transaction.
+    absl::MutexLock lock(&m_mutex);
+
     if ((submits_ptr != nullptr) && (submits_ptr->pCommandBuffers != nullptr))
     {
         for (uint32_t i = 0; i < submit_count; i++)
@@ -903,8 +915,17 @@ GPUTime::SubmitStatus GPUTime::OnQueueSubmit(uint32_t submit_count, const VkSubm
 
     if (is_frame_boundary)
     {
+        // Manually unlock the underlying mutex around the blocking wait
+        // to prevent holding up other threads, then immediately reacquire.
+        m_mutex.Unlock();
+
+        //  force sync to make sure the gpu is done with this frame
+        pfn_device_wait_idle(m_device);
+
+        m_mutex.Lock();
+
         GPUTime::GpuTimeStatus update_status =
-            OnFrameBoundary(pfn_device_wait_idle, pfn_reset_query_pool, pfn_get_query_pool_results);
+            OnFrameBoundary(pfn_reset_query_pool, pfn_get_query_pool_results);
 
         if (!update_status.success)
         {
@@ -922,18 +943,23 @@ GPUTime::GpuTimeStatus GPUTime::OnQueuePresent(PFN_vkDeviceWaitIdle pfn_device_w
     {
         return GPUTime::GpuTimeStatus();
     }
+    //  force sync to make sure the gpu is done with this frame
+    pfn_device_wait_idle(m_device);
 
-    return OnFrameBoundary(pfn_device_wait_idle, pfn_reset_query_pool, pfn_get_query_pool_results);
+    absl::MutexLock lock(&m_mutex);
+    return OnFrameBoundary(pfn_reset_query_pool, pfn_get_query_pool_results);
 }
 
 GPUTime::GpuTimeStatus GPUTime::OnGetDeviceQueue2(VkQueue* pQueue)
 {
+    absl::MutexLock lock(&m_mutex);
     m_queues.insert(*pQueue);
     return GPUTime::GpuTimeStatus();
 }
 
 GPUTime::GpuTimeStatus GPUTime::OnGetDeviceQueue(VkQueue* pQueue)
 {
+    absl::MutexLock lock(&m_mutex);
     m_queues.insert(*pQueue);
     return GPUTime::GpuTimeStatus();
 }
@@ -986,7 +1012,11 @@ GPUTime::GpuTimeStatus GPUTime::OnCmdEndRenderPass2KHR(
     return EndRenderPass(command_buffer, pfn_cmd_write_timestamp);
 }
 
-void GPUTime::ClearFrameCache() { m_frame_cmds.clear(); }
+void GPUTime::ClearFrameCache()
+{
+    absl::MutexLock lock(&m_mutex);
+    m_frame_cmds.clear();
+}
 
 GPUTime::GpuTimeStatus GPUTime::BeginRenderPass(VkCommandBuffer command_buffer,
                                                 PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp)
@@ -996,6 +1026,7 @@ GPUTime::GpuTimeStatus GPUTime::BeginRenderPass(VkCommandBuffer command_buffer,
         return GPUTime::GpuTimeStatus();
     }
 
+    absl::MutexLock lock(&m_mutex);
     auto iter = m_cmds.find(command_buffer);
     if (iter == m_cmds.end())
     {
@@ -1018,6 +1049,7 @@ GPUTime::GpuTimeStatus GPUTime::EndRenderPass(VkCommandBuffer command_buffer,
         return GPUTime::GpuTimeStatus();
     }
 
+    absl::MutexLock lock(&m_mutex);
     auto iter = m_cmds.find(command_buffer);
     if (iter == m_cmds.end())
     {

--- a/gpu_time/gpu_time.h
+++ b/gpu_time/gpu_time.h
@@ -26,6 +26,8 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "frame_boundary_detector.h"
 
 namespace Dive
@@ -71,40 +73,48 @@ class GPUTime
                                  float timestamp_period,
                                  PFN_vkCreateQueryPool pfn_create_query_pool,
                                  PFN_vkResetQueryPool pfn_reset_query_pool,
-                                 PFN_vkDestroyQueryPool pfn_destroy_query_pool);
+                                 PFN_vkDestroyQueryPool pfn_destroy_query_pool)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
-    GpuTimeStatus OnDestroyDevice(VkDevice device, PFN_vkQueueWaitIdle pfn_queue_wait_idle);
+    GpuTimeStatus OnDestroyDevice(VkDevice device, PFN_vkQueueWaitIdle pfn_queue_wait_idle)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
-    GpuTimeStatus OnDestroyCommandPool(VkCommandPool command_pool);
+    GpuTimeStatus OnDestroyCommandPool(VkCommandPool command_pool) ABSL_LOCKS_EXCLUDED(m_mutex);
 
     GpuTimeStatus OnAllocateCommandBuffers(const VkCommandBufferAllocateInfo* allocate_info_ptr,
-                                           VkCommandBuffer* command_buffers_ptr);
+                                           VkCommandBuffer* command_buffers_ptr)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
     GpuTimeStatus OnFreeCommandBuffers(uint32_t command_buffer_count,
-                                       const VkCommandBuffer* command_buffers_ptr);
+                                       const VkCommandBuffer* command_buffers_ptr)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
-    GpuTimeStatus OnResetCommandBuffer(VkCommandBuffer command_buffer);
+    GpuTimeStatus OnResetCommandBuffer(VkCommandBuffer command_buffer) ABSL_LOCKS_EXCLUDED(m_mutex);
 
-    GpuTimeStatus OnResetCommandPool(VkCommandPool command_pool);
+    GpuTimeStatus OnResetCommandPool(VkCommandPool command_pool) ABSL_LOCKS_EXCLUDED(m_mutex);
 
     GpuTimeStatus OnBeginCommandBuffer(VkCommandBuffer command_buffer,
                                        VkCommandBufferUsageFlags flags,
-                                       PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp);
+                                       PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
     GpuTimeStatus OnEndCommandBuffer(VkCommandBuffer command_buffer,
-                                     PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp);
+                                     PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
     SubmitStatus OnQueueSubmit(uint32_t submit_count, const VkSubmitInfo* submits_ptr,
                                PFN_vkDeviceWaitIdle pfn_device_wait_idle,
                                PFN_vkResetQueryPool pfn_reset_query_pool,
-                               PFN_vkGetQueryPoolResults pfn_get_query_pool_results);
+                               PFN_vkGetQueryPoolResults pfn_get_query_pool_results)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
     GpuTimeStatus OnQueuePresent(PFN_vkDeviceWaitIdle pfn_device_wait_idle,
                                  PFN_vkResetQueryPool pfn_reset_query_pool,
-                                 PFN_vkGetQueryPoolResults pfn_get_query_pool_results);
+                                 PFN_vkGetQueryPoolResults pfn_get_query_pool_results)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
-    GpuTimeStatus OnGetDeviceQueue2(VkQueue* pQueue);
-    GpuTimeStatus OnGetDeviceQueue(VkQueue* pQueue);
+    GpuTimeStatus OnGetDeviceQueue2(VkQueue* pQueue) ABSL_LOCKS_EXCLUDED(m_mutex);
+    GpuTimeStatus OnGetDeviceQueue(VkQueue* pQueue) ABSL_LOCKS_EXCLUDED(m_mutex);
 
     GpuTimeStatus OnCmdInsertDebugUtilsLabelEXT(VkCommandBuffer command_buffer,
                                                 const VkDebugUtilsLabelEXT* label_info_ptr);
@@ -135,21 +145,31 @@ class GPUTime
         double max = std::numeric_limits<double>::lowest();
         double stddev = 0.0;
     };
-    Stats GetFrameTimeStats() const { return m_metrics.GetFrameTimeStats(); }
-    Stats GetFrameCmdTimeStats(size_t index) const { return m_metrics.GetFrameCmdTimeStats(index); }
-    Stats GetFrameRenderPassTimeStats(size_t index) const
+    Stats GetFrameTimeStats() const ABSL_LOCKS_EXCLUDED(m_mutex)
     {
+        absl::MutexLock lock(&m_mutex);
+        return m_metrics.GetFrameTimeStats();
+    }
+    Stats GetFrameCmdTimeStats(size_t index) const ABSL_LOCKS_EXCLUDED(m_mutex)
+    {
+        absl::MutexLock lock(&m_mutex);
+        return m_metrics.GetFrameCmdTimeStats(index);
+    }
+    Stats GetFrameRenderPassTimeStats(size_t index) const ABSL_LOCKS_EXCLUDED(m_mutex)
+    {
+        absl::MutexLock lock(&m_mutex);
         return m_metrics.GetFrameRenderPassTimeStats(index);
     }
-    size_t GetCmdRenderPassCount(size_t index) const
+    size_t GetCmdRenderPassCount(size_t index) const ABSL_LOCKS_EXCLUDED(m_mutex)
     {
+        absl::MutexLock lock(&m_mutex);
         return m_metrics.GetCmdRenderPassCount(index);
     }
-    std::string GetStatsString() const;
+    std::string GetStatsString() const ABSL_LOCKS_EXCLUDED(m_mutex);
     // Gives a CSV format string representing the GPU timing data for objects in the current frame
     // Type, id, mean [ms], median [ms]
-    std::string GetStatsCSVString() const;
-    void ClearFrameCache();
+    std::string GetStatsCSVString() const ABSL_LOCKS_EXCLUDED(m_mutex);
+    void ClearFrameCache() ABSL_LOCKS_EXCLUDED(m_mutex);
 
  private:
     class FrameMetrics
@@ -219,35 +239,48 @@ class GPUTime
         bool reusable = false;
     };
 
-    GpuTimeStatus OnFrameBoundary(PFN_vkDeviceWaitIdle pfn_device_wait_idle,
-                                  PFN_vkResetQueryPool pfn_reset_query_pool,
-                                  PFN_vkGetQueryPoolResults pfn_get_query_pool_results);
-    GpuTimeStatus UpdateFrameMetrics(PFN_vkGetQueryPoolResults pfn_get_query_pool_results);
-    void RemoveCmdFromFrameCache(VkCommandBuffer cmd);
+    GpuTimeStatus OnFrameBoundary(PFN_vkResetQueryPool pfn_reset_query_pool,
+                                  PFN_vkGetQueryPoolResults pfn_get_query_pool_results)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+
+    GpuTimeStatus UpdateFrameMetrics(PFN_vkGetQueryPoolResults pfn_get_query_pool_results)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+
+    void RemoveCmdFromFrameCache(VkCommandBuffer cmd) ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+
     GpuTimeStatus BeginRenderPass(VkCommandBuffer command_buffer,
-                                  PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp);
+                                  PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
+
     GpuTimeStatus EndRenderPass(VkCommandBuffer command_buffer,
-                                PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp);
+                                PFN_vkCmdWriteTimestamp pfn_cmd_write_timestamp)
+        ABSL_LOCKS_EXCLUDED(m_mutex);
 
     FrameBoundaryDetector m_boundary_detector;
 
+    mutable absl::Mutex m_mutex;
+
     // Keep the timestamp results *2 for VK_QUERY_RESULT_WITH_AVAILABILITY_BIT
-    uint64_t m_timestamps_with_availability[TimeStampSlotAllocator::kTotalSlots * 2]{};
-    FrameMetrics m_metrics;
+    uint64_t m_timestamps_with_availability[TimeStampSlotAllocator::kTotalSlots *
+                                            2] ABSL_GUARDED_BY(m_mutex) = {};
+    FrameMetrics m_metrics ABSL_GUARDED_BY(m_mutex);
+    std::set<VkQueue> m_queues ABSL_GUARDED_BY(m_mutex);
+    std::unordered_map<VkCommandBuffer, CommandBufferInfo> m_cmds ABSL_GUARDED_BY(m_mutex);
+    std::vector<VkCommandBuffer> m_frame_cmds ABSL_GUARDED_BY(m_mutex);
+    TimeStampSlotAllocator m_timestamp_allocator ABSL_GUARDED_BY(m_mutex);
 
-    std::set<VkQueue> m_queues;
-    std::unordered_map<VkCommandBuffer, CommandBufferInfo> m_cmds;
-    std::vector<VkCommandBuffer> m_frame_cmds;
-    TimeStampSlotAllocator m_timestamp_allocator;
-
+    // The following variables are initialized once during OnCreateDevice and are not
+    // expected to be modified in a multi-threaded context. Therefore, they do not
+    // require mutex protection.
     VkDevice m_device = VK_NULL_HANDLE;
     const VkAllocationCallbacks* m_allocator = nullptr;
     VkQueryPool m_query_pool = VK_NULL_HANDLE;
     PFN_vkDestroyQueryPool m_destroy_query_pool = nullptr;
-    uint64_t m_frame_index = 0;
     float m_timestamp_period = 0.0f;
-    bool m_valid_frame = true;
-    bool m_enable = false;
+
+    uint64_t m_frame_index ABSL_GUARDED_BY(m_mutex) = 0;
+    bool m_valid_frame ABSL_GUARDED_BY(m_mutex) = true;
+    std::atomic<bool> m_enable = false;
 };
 
 }  // namespace Dive

--- a/gpu_time/gpu_time_benchmark.cpp
+++ b/gpu_time/gpu_time_benchmark.cpp
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <benchmark/benchmark.h>
+
+#include "gpu_time.h"
+
+namespace Dive
+{
+namespace
+{
+
+#define MOCK_HANDLE(type, name, val) \
+    const type name = reinterpret_cast<type>(static_cast<uintptr_t>(val));
+
+MOCK_HANDLE(VkDevice, MOCK_DEVICE, 0x1);
+MOCK_HANDLE(VkQueue, MOCK_QUEUE, 0x2);
+MOCK_HANDLE(VkCommandPool, MOCK_COMMAND_POOL, 0x3);
+MOCK_HANDLE(VkQueryPool, MOCK_QUERY_POOL, 0x4);
+
+VkResult MockCreateQueryPool(VkDevice, const VkQueryPoolCreateInfo*, const VkAllocationCallbacks*,
+                             VkQueryPool* pQueryPool)
+{
+    *pQueryPool = MOCK_QUERY_POOL;
+    return VK_SUCCESS;
+}
+
+void MockDestroyQueryPool(VkDevice, VkQueryPool, const VkAllocationCallbacks*) {}
+void MockResetQueryPool(VkDevice, VkQueryPool, uint32_t, uint32_t) {}
+void MockCmdWriteTimestamp(VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, uint32_t) {}
+VKAPI_ATTR VkResult VKAPI_CALL MockQueueWaitIdle(VkQueue) { return VK_SUCCESS; }
+
+GPUTime g_gpu_time;
+std::vector<VkCommandBuffer> g_cmds;
+constexpr size_t max_thread_count = 16;
+
+struct GlobalSetup
+{
+    GlobalSetup()
+    {
+        g_gpu_time.SetEnable(true);
+        g_gpu_time.OnCreateDevice(MOCK_DEVICE, nullptr, 1.0f, MockCreateQueryPool,
+                                  MockResetQueryPool, MockDestroyQueryPool);
+
+        g_cmds.resize(max_thread_count);
+        VkCommandBufferAllocateInfo alloc_info = {};
+        alloc_info.commandPool = MOCK_COMMAND_POOL;
+        alloc_info.commandBufferCount = 1;
+
+        for (int i = 0; i < max_thread_count; ++i)
+        {
+            g_cmds[i] = reinterpret_cast<VkCommandBuffer>(static_cast<uintptr_t>(0x1000 + i));
+            g_gpu_time.OnAllocateCommandBuffers(&alloc_info, &g_cmds[i]);
+        }
+    }
+
+    ~GlobalSetup()
+    {
+        VkQueue queue = MOCK_QUEUE;
+        g_gpu_time.OnGetDeviceQueue(&queue);
+        g_gpu_time.OnDestroyDevice(MOCK_DEVICE, MockQueueWaitIdle);
+    }
+} g_setup_instance;
+
+void BM_RecordCommandBuffers(benchmark::State& state)
+{
+    VkCommandBuffer cmd = g_cmds[state.thread_index()];
+
+    for (auto _ : state)
+    {
+        g_gpu_time.OnBeginCommandBuffer(cmd, 0, MockCmdWriteTimestamp);
+        g_gpu_time.OnCmdBeginRenderPass(cmd, MockCmdWriteTimestamp);
+
+        // Simulate CPU overhead of doing actual Vulkan command binding/drawing
+        benchmark::ClobberMemory();
+
+        g_gpu_time.OnCmdEndRenderPass(cmd, MockCmdWriteTimestamp);
+        g_gpu_time.OnEndCommandBuffer(cmd, MockCmdWriteTimestamp);
+    }
+}
+
+BENCHMARK(BM_RecordCommandBuffers)->ThreadRange(1, max_thread_count)->UseRealTime();
+
+}  // namespace
+}  // namespace Dive


### PR DESCRIPTION
- It fixes the potential issue with race condition for m_cmds and m_frame_cmds at GPUTime as multiple threads can invoke at the same time the methods modifying their values.