### PR TITLE
Fixes freezing/trace stats loading on windows

### DIFF
--- a/ui/capture_file_manager.cpp
+++ b/ui/capture_file_manager.cpp
@@ -92,7 +92,11 @@ void CaptureFileManager::OnGatherTraceStatsDone()
     m_working = false;
     if (!m_pending_request)
     {
-        TraceStatsUpdated();
+        emit TraceStatsUpdated();
+    }
+    else
+    {
+        StartLoadFile();
     }
 }
 
@@ -306,7 +310,7 @@ void CaptureFileManager::GatherTraceStats()
     m_working = true;
     QMetaObject::invokeMethod(m_worker, [this, context = m_capture_file_context]() {
         GatherTraceStatsImpl(context);
-        GatherTraceStatsDone();
+        emit GatherTraceStatsDone();
     });
 }
 


### PR DESCRIPTION
Adds a StartLoadFile() fallback inside the CaptureFileManager to ensure that as soon as the worker thread was free, the pending file load request is processed. This prevents the ui from freezing when a user attempts to open another file before the trace stats for the previous file were loaded.

**Manual Testing:**
GWindows
- Load demeo gfxr/rd capture, Load subsampled gfxr/rd capture as soon as ui is responsive. Ensure no UI freeze, trace stats for subsampled application are displayed