### PR TITLE
Adds message to overview tabs indicating stats are being loaded

### DIFF
--- a/ui/main_window.cpp
+++ b/ui/main_window.cpp
@@ -946,6 +946,7 @@ void MainWindow::OnGfxrFileLoaded()
 void MainWindow::StartTraceStats()
 {
     *m_capture_stats = {};
+    m_overview_tab_view->setProperty("is_loading", true);
     m_overview_tab_view->LoadStatistics();
     m_capture_manager->GatherTraceStats();
 }
@@ -953,6 +954,7 @@ void MainWindow::StartTraceStats()
 void MainWindow::OnTraceStatsUpdated()
 {
     m_capture_manager->FillCaptureStatsResult(*m_capture_stats);
+    m_overview_tab_view->setProperty("is_loading", false);
     m_overview_tab_view->LoadStatistics();
 }
 

--- a/ui/overview_tab_view.cpp
+++ b/ui/overview_tab_view.cpp
@@ -20,8 +20,10 @@
 #include <qobject.h>
 
 #include <QApplication>
+#include <QLabel>
 #include <QSplitter>
 #include <QVBoxLayout>
+#include <QVariant>
 
 #include "dive_core/data_core.h"
 #include "draw_dispatch_stats_tab_view.h"
@@ -53,7 +55,16 @@ OverviewTabView::OverviewTabView(const Dive::CaptureMetadata& capture_metadata,
     m_tile_statistics_view_tab_index = m_tab_widget->addTab(m_tile_statistics_view, "Tile Stats");
     m_misc_statistics_view_tab_index = m_tab_widget->addTab(m_misc_statistics_view, "Misc Stats");
 
+    QLabel* loading_label = new QLabel(tr("Gathering Trace Stats..."));
+    loading_label->setObjectName("loading_label");
+    loading_label->setAlignment(Qt::AlignCenter);
+    QFont font = loading_label->font();
+    font.setPointSize(16);
+    loading_label->setFont(font);
+    loading_label->hide();
+
     QVBoxLayout* main_layout = new QVBoxLayout();
+    main_layout->addWidget(loading_label);
     main_layout->addWidget(m_tab_widget);
     setLayout(main_layout);
 
@@ -64,9 +75,20 @@ OverviewTabView::OverviewTabView(const Dive::CaptureMetadata& capture_metadata,
 // --------------------------------------------------------------------------------------------------
 void OverviewTabView::LoadStatistics()
 {
-    m_tile_statistics_view->LoadStatistics();
-    m_draw_dispatch_statistics_view->LoadStatistics();
-    m_misc_statistics_view->LoadStatistics();
+    bool is_loading = property("is_loading").toBool();
+    QLabel* loading_label = findChild<QLabel*>("loading_label");
+    if (loading_label)
+    {
+        loading_label->setVisible(is_loading);
+        m_tab_widget->setVisible(!is_loading);
+    }
+
+    if (!is_loading)
+    {
+        m_tile_statistics_view->LoadStatistics();
+        m_draw_dispatch_statistics_view->LoadStatistics();
+        m_misc_statistics_view->LoadStatistics();
+    }
 }
 
 // --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds message to overview tabs indicating stats are being loaded instead of just showing blank views

<img width="1920" height="913" alt="Screenshot 2026-04-09 at 3 59 15 PM" src="https://github.com/user-attachments/assets/b0e57ef5-dec2-408b-b05f-b911b137e91b" />
