### PR TITLE
Add thread safety static analysis to Actions

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -12,6 +12,9 @@ on:
       cxx:
         required: true
         type: string
+      cxx_flags:
+        required: true
+        type: string
       restore_cache:
         required: true
         type: boolean

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -71,6 +71,7 @@ jobs:
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/${INPUTS_CC} \
             -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/${INPUTS_CXX} \
+            -DCMAKE_CXX_FLAGS="${INPUTS_CXX_FLAGS}"
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DDIVE_BUILD_WITH_CRASHPAD=OFF \
@@ -78,6 +79,7 @@ jobs:
         env:
           INPUTS_CC: ${{ inputs.cc }}
           INPUTS_CXX: ${{ inputs.cxx }}
+          INPUTS_CXX_FLAGS: ${{ inputs.cxx_flags }}
       - name: Build Dive host tools with ninja with ${{ inputs.cc }}
         run: |
           ninja -C build/host -f build-${INPUTS_BUILD_TYPE}.ninja

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -74,7 +74,7 @@ jobs:
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/${INPUTS_CC} \
             -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/${INPUTS_CXX} \
-            -DCMAKE_CXX_FLAGS="${INPUTS_CXX_FLAGS}"
+            -DCMAKE_CXX_FLAGS="${INPUTS_CXX_FLAGS}" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DDIVE_BUILD_WITH_CRASHPAD=OFF \

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -24,14 +24,17 @@ jobs:
           - build_type: RelWithDebInfo
             cc: gcc-14
             cxx: g++-14
+            cxx_flags: ""
           - build_type: RelWithDebInfo
             cc: clang-19
             cxx: clang++-19
+            cxx_flags: "-Wthread-safety"
     uses: ./.github/workflows/build_linux.yml
     with:
       build_type: ${{ matrix.build_type }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
+      cxx_flags: ${{ matrix.cxx_flags }}
       restore_cache: true
       upload_cache: false
 

--- a/.github/workflows/weekdays.yml
+++ b/.github/workflows/weekdays.yml
@@ -20,13 +20,16 @@ jobs:
         include:
           - cc: gcc-14
             cxx: g++-14
+            cxx_flags: ""
           - cc: clang-19
             cxx: clang++-19
+            cxx_flags: "-Wthread-safety"
     uses: ./.github/workflows/build_linux.yml
     with:
       build_type: ${{ matrix.build_type }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
+      cxx_flags: ${{ matrix.cxx_flags }}
       restore_cache: false
       upload_cache: true
 

--- a/capture_service/android_trace_mgr.cc
+++ b/capture_service/android_trace_mgr.cc
@@ -122,8 +122,8 @@ void AndroidTraceManager::WaitForTraceDone()
 {
     // TODO(renfeng): add timeout.
     m_state_lock.Lock();
-    auto capture_done = [this] { return m_state == TraceState::Finished; };
-    m_state_lock.Await(absl::Condition(&capture_done));
+    m_state_lock.Await(absl::Condition(
+        +[](TraceState* state) { return *state == TraceState::Finished; }, &m_state));
     m_state_lock.Unlock();
 }
 

--- a/capture_service/trace_mgr.h
+++ b/capture_service/trace_mgr.h
@@ -66,9 +66,9 @@ class AndroidTraceManager : public TraceManager
     // `trace_duration` is ignored during trace by frame.
     explicit AndroidTraceManager(absl::Duration trace_duration = absl::Seconds(3));
 
-    void TriggerTrace() override;
-    void OnNewFrame() override;
-    void WaitForTraceDone() override;
+    void TriggerTrace() override ABSL_LOCKS_EXCLUDED(m_state_lock);
+    void OnNewFrame() override ABSL_LOCKS_EXCLUDED(m_state_lock);
+    void WaitForTraceDone() override ABSL_LOCKS_EXCLUDED(m_state_lock);
 
     TraceState GetState() ABSL_LOCKS_EXCLUDED(m_state_lock)
     {
@@ -77,12 +77,12 @@ class AndroidTraceManager : public TraceManager
     }
 
  private:
-    void TraceByFrame();
-    void TraceByDuration();
-    bool ShouldStartTrace() const;
-    bool ShouldStopTrace() const;
-    void OnTraceStart();
-    void OnTraceStop();
+    void TraceByFrame() ABSL_LOCKS_EXCLUDED(m_state_lock);
+    void TraceByDuration() ABSL_LOCKS_EXCLUDED(m_state_lock);
+    bool ShouldStartTrace() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock);
+    bool ShouldStopTrace() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock);
+    void OnTraceStart() ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock);
+    void OnTraceStop() ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock);
     absl::Mutex m_state_lock;
     TraceState m_state ABSL_GUARDED_BY(m_state_lock) = TraceState::Idle;
     uint32_t m_frame_num = 0;


### PR DESCRIPTION
-Wthread-safety enables thread static analysis guided by thread annotations. It will warn about potential race conditions.

The easiest way to start using thread annotations is with absl::Mutex and absl/synchronization/thread_annotations.h. The headers and Abseil website have documentation: https://abseil.io/docs/cpp/guides/synchronization

For more information, see https://clang.llvm.org/docs/ThreadSafetyAnalysis.html