### PR TITLE
Reorders resource directories

### DIFF
--- a/src/dive/utils/device_resources.cpp
+++ b/src/dive/utils/device_resources.cpp
@@ -78,11 +78,11 @@ absl::StatusOr<std::filesystem::path> ResolvePluginsDir()
     std::filesystem::path base_dir_installed = "..";
     std::filesystem::path dive_build_root_dev = "../../..";
     std::array search_dirs = {
-        // Most platforms
-        base_dir_installed / CMAKE_GENERATED_PLUGINS_PARENT_DIR,
         // Apple bundle
         base_dir_installed / CMAKE_GENERATED_DIVE_MACOS_BUNDLE_RESOURCES /
             CMAKE_GENERATED_PLUGINS_PARENT_DIR,
+        // Most platforms
+        base_dir_installed / CMAKE_GENERATED_PLUGINS_PARENT_DIR,
         // For launching host tool from Windows VS debugger, assuming other parts were installed
         // under pkg/
         dive_build_root_dev / "pkg" / CMAKE_GENERATED_PLUGINS_PARENT_DIR,
@@ -124,10 +124,10 @@ absl::StatusOr<std::filesystem::path> ResolveDeviceResourcesLocalPath(
     std::filesystem::path base_dir_installed = "..";
     std::filesystem::path dive_build_root_dev = "../../..";
     std::array search_dirs = {
-        // Most platforms
-        base_dir_installed / CMAKE_GENERATED_INSTALL_DEST_DEVICE,
         // Apple bundle
         base_dir_installed / CMAKE_GENERATED_DIVE_MACOS_BUNDLE_RESOURCES,
+        // Most platforms
+        base_dir_installed / CMAKE_GENERATED_INSTALL_DEST_DEVICE,
         // For launching host tool from Windows VS debugger, assuming other parts were installed
         // under pkg/
         dive_build_root_dev / "pkg" / CMAKE_GENERATED_INSTALL_DEST_DEVICE,
@@ -143,12 +143,12 @@ absl::StatusOr<std::filesystem::path> ResolveProfilingResourcesLocalPath(
     std::filesystem::path base_dir_installed = "..";
     std::filesystem::path dive_build_root_dev = "../../..";
     std::array search_dirs = {
-        // Most platforms
-        base_dir_installed / CMAKE_GENERATED_PLUGINS_PARENT_DIR /
-            CMAKE_GENERATED_PROFILING_PLUGIN_DIR,
         // Apple bundle
         base_dir_installed / CMAKE_GENERATED_DIVE_MACOS_BUNDLE_RESOURCES /
             CMAKE_GENERATED_PLUGINS_PARENT_DIR / CMAKE_GENERATED_PROFILING_PLUGIN_DIR,
+        // Most platforms
+        base_dir_installed / CMAKE_GENERATED_PLUGINS_PARENT_DIR /
+            CMAKE_GENERATED_PROFILING_PLUGIN_DIR,
         // For launching host tool from Windows VS debugger, assuming other parts were installed
         // under pkg/
         dive_build_root_dev / "pkg" / CMAKE_GENERATED_PLUGINS_PARENT_DIR /


### PR DESCRIPTION
Reordered the search_dirs arrays in ResolvePluginsDir, ResolveDeviceResourcesLocalPath, and ResolveProfilingResourcesLocalPath to prioritize the Apple bundle specific paths. Currently the generic "Most platforms" fallback path is listed first. If using the local build directory structure, the app would match that first and completely ignore the .app bundle's Resources directory, causing failures. Prioritizing the Apple bundle paths ensures the app will correctly look inside its own packaged Resources directory first. If it doesn't exist (running on Linux/Windows), it falls back to the standard generic paths.