### PR TITLE
Updates assert for subsampled captures

### DIFF
--- a/dive_core/capture_event_info.cpp
+++ b/dive_core/capture_event_info.cpp
@@ -457,7 +457,9 @@ bool Util::ShouldIgnoreEventDuringCorrelation(const IMemoryManager& mem_manager,
 
     if (packet.bitfields0.PRIM_TYPE == DI_PT_RECTLIST)
     {
-        DIVE_ASSERT(packet.bitfields2.NUM_INDICES == 2);
+        // The driver can batch multiple rectangles for MSAA/subsampled clears and resolves.
+        // Each rectangle requires 2 indices.
+        DIVE_ASSERT(packet.bitfields2.NUM_INDICES > 0 && packet.bitfields2.NUM_INDICES % 2 == 0);
         return true;
     }
 


### PR DESCRIPTION
Supports PM4 capture of applications that use subsampled images with and without course reconstruction.

When MSAA or subsampling is active, the driver batches multiple rectangles into a single draw packet to improve performance. This exceeded the expected index count and triggered an assertion.

Manual Testing:
Linux

Load subsampled demeo rd capture, no crash occurs.