### PR TITLE
Always cleanup /data/local/debug/vulkan

### DIFF
--- a/capture_service/android_application.cc
+++ b/capture_service/android_application.cc
@@ -180,6 +180,13 @@ absl::Status AndroidApplication::Cleanup()
     m_dev.Adb().Run("shell settings delete global gpu_debug_layers").IgnoreError();
     m_dev.Adb().Run("shell settings delete global gpu_debug_layer_app").IgnoreError();
     m_dev.Adb().Run("shell settings delete global gpu_debug_layers_gles").IgnoreError();
+    
+    // Clean up layer folder used by CLI since it impacts all Vulkan applications.
+    AdbSession& adb = m_dev.Adb();
+    adb.Run(absl::StrFormat("shell rm -rf -- %s",
+                            Dive::DeviceResourcesConstants::kDeployVulkanGlobalFolderPath))
+        .IgnoreError();
+    adb.Run(absl::StrFormat("shell setprop debug.vulkan.layers \"''\"")).IgnoreError();
 
     m_gfxr_enabled = false;
     m_runtime_what_if_enabled = false;
@@ -667,23 +674,6 @@ absl::Status VulkanCliApplication::Pm4CaptureSetup()
         /*target_dir=*/Dive::DeviceResourcesConstants::kDeployVulkanGlobalFolderPath));
     RETURN_IF_ERROR(
         m_dev.Adb().Run(absl::StrFormat("shell setprop debug.vulkan.layers %s", kVkLayerName)));
-    return absl::OkStatus();
-}
-
-absl::Status VulkanCliApplication::Pm4CaptureCleanup() { return absl::OkStatus(); }
-
-absl::Status VulkanCliApplication::Cleanup()
-{
-    RETURN_IF_ERROR(m_dev.Adb().Run(absl::StrFormat(
-        "shell rm -fr %s", Dive::DeviceResourcesConstants::kDeployVulkanGlobalFolderPath)));
-    RETURN_IF_ERROR(m_dev.Adb().Run(absl::StrFormat("shell setprop debug.vulkan.layers \"''\"")));
-
-    auto status = AndroidApplication::Cleanup();
-    if (!status.ok())
-    {
-        return status;
-    }
-
     return absl::OkStatus();
 }
 

--- a/capture_service/android_application.cc
+++ b/capture_service/android_application.cc
@@ -180,7 +180,7 @@ absl::Status AndroidApplication::Cleanup()
     m_dev.Adb().Run("shell settings delete global gpu_debug_layers").IgnoreError();
     m_dev.Adb().Run("shell settings delete global gpu_debug_layer_app").IgnoreError();
     m_dev.Adb().Run("shell settings delete global gpu_debug_layers_gles").IgnoreError();
-    
+
     // Clean up layer folder used by CLI since it impacts all Vulkan applications.
     AdbSession& adb = m_dev.Adb();
     adb.Run(absl::StrFormat("shell rm -rf -- %s",

--- a/capture_service/android_application.h
+++ b/capture_service/android_application.h
@@ -153,9 +153,6 @@ class VulkanCliApplication : public AndroidApplication
     ~VulkanCliApplication() override;
     absl::Status Setup() override;
 
-    // Cleanup for device properties and settings related to a Vulkan CLI application
-    absl::Status Cleanup() override;
-
     absl::Status Start() override;
     absl::Status Stop() override;
     bool IsRunning() const override;
@@ -164,7 +161,6 @@ class VulkanCliApplication : public AndroidApplication
 
  private:
     absl::Status Pm4CaptureSetup() override;
-    absl::Status Pm4CaptureCleanup() override;
     absl::Status WaitForProcessToStart();
     std::string m_command;
     std::string m_pid;


### PR DESCRIPTION
If VulkanCliApplication::Cleanup is never run for whatever reason (e.g. the program crashes) then the global layer can be left on the device. This will be injected into every Vulkan application that starts. This can interfere with other capture and replay attempts. Make sure that it's always cleaned up.