### PR TITLE
More updates for build script focused on plugins and clean build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ third_party/dive_crashpad/prebuilt
 
 # Build-related directories
 build/
+plugins/external/
 third_party/freedreno/libs/
 third_party/freedreno/obj
 .gradle/

--- a/BUILD.md
+++ b/BUILD.md
@@ -89,12 +89,14 @@ export PATH=$QTDIR/bin:$PATH
 export DIVE_ROOT_PATH=~/src/dive
 ```
 
+# External Dive Plugins
+Place pre-built plugins under `plugins/external/` and they will be copied to `build/pkg/plugins/` by the build script automatically.
+
 # Building Dive
 
 ## Host and Device Libraries
 
 This will run the default (entire) build process except for:
-* Placing external (to this repo) plugins in the appropriate folder `build/pkg/plugins/`
 * On macOS, for Debug builds, you will still need to make the app bundle and sign it
 * Cross-platform release process
 
@@ -112,9 +114,9 @@ python scripts/build.py --build-via-generator
 ### Custom Building Tips
 
 * On Windows, using the Visual Studio UI for the host build can be clearer than building it on the command line. To do that, split the build process like so:
-    1. Generate the Visual Studio Solution
+    1. Do all actions up to and including generating the Visual Studio Solution
         ```bat
-        python scripts/build.py --actions configure_host
+        python scripts/build.py --actions < the prior... >,configure_host
         ```
     1. Compile manually in Visual Studio (same as `python scripts/build.py --actions build_host`)
         * Open Visual Studio UI and build target ALL_BUILD

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,3 @@
+# Instructions
+
+Place directories containing prebuilt external Dive plugins under `plugins/external` before building Dive with `scripts/build.py`. The external plugins will be copied over to the build package folder.

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -165,15 +165,13 @@ def check_environment(args):
 
 
 def clean_build(args):
-    """Delete args.root_build_dir
-    """
-    if os.path.exists(f"{args.root_build_dir}"):
+    if os.path.exists(args.root_build_dir):
         print("\nClearing build folder...")
-        shutil.rmtree(f"{args.root_build_dir}")
+        shutil.rmtree(args.root_build_dir)
 
 
 def copy_plugins(args):
-    """Implementing ActionType.COPY_PLUGINS stage
+    """Implements ActionType.COPY_PLUGINS stage
     """
     if not os.path.exists(EXTERNAL_PLUGINS_DIR):
         print(f"\nDir {EXTERNAL_PLUGINS_DIR} does not exist, skipping")

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -31,11 +31,11 @@ NINJA_MULTI_CONFIG_NAME = "Ninja Multi-Config"
 
 # TODO: b/484082504 - Add more stages for packaging and deploying (incorporate scripts/deploy_mac_bundle.py)
 class ActionType(enum.StrEnum):
+    COPY_PLUGINS = "copy_plugins"       # copy external plugins into pkg dir
     CONFIGURE_HOST = "configure_host"
     BUILD_HOST = "build_host"           # separated to make VS builds using the UI easy
     INSTALL_HOST = "install_host"
     ALL_DEVICE = "all_device"           # configure, build, and install device libraries
-
 
 class BuildType(enum.StrEnum):
     DEBUG = "Debug"
@@ -160,6 +160,18 @@ def check_environment(args):
     if (platform.system() == "Windows") and (args.build_via_generator):
         cmd = [args.msbuild_exec, "--version"]
         dive.echo_and_run(cmd)
+
+
+def copy_plugins(args):
+    """Implementing ActionType.COPY_PLUGINS stage
+    """
+    if args.clean_build:
+        if os.path.exists(f"{args.root_build_dir}/pkg/plugins"):
+            print("\nClearing plugins folders...")
+            shutil.rmtree(f"{args.root_build_dir}/pkg/plugins")
+
+    print("\nCopying over external plugins...")
+    shutil.copytree("plugins/external", f"{args.root_build_dir}/pkg/plugins/", dirs_exist_ok=True)
 
 
 def configure_host(args):
@@ -305,6 +317,9 @@ def main():
             print(f"\nChecking build environment...")
             check_environment(args)
 
+        if ActionType.COPY_PLUGINS in actions:
+            with dive.Timer(ActionType.COPY_PLUGINS):
+                copy_plugins(args)
         if ActionType.CONFIGURE_HOST in actions:
             with dive.Timer(ActionType.CONFIGURE_HOST):
                 configure_host(args)
@@ -317,8 +332,6 @@ def main():
         if ActionType.ALL_DEVICE in actions:
             with dive.Timer(ActionType.ALL_DEVICE):
                 all_device(args)
-
-    print(f"\nTIP: Remember to place plugins in build/pkg/plugins")
 
 
 if __name__ == "__main__":

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -23,6 +23,8 @@ import shutil
 
 
 # GLOBAL CONSTANTS
+# Dive directory structure relative to root Dive dir
+EXTERNAL_PLUGINS_DIR = "plugins/external"
 # Build directory structure relative to --root-build-dir
 PKG_DIR = "pkg"
 # CMake generator names
@@ -74,7 +76,7 @@ def parse_args():
     parser.add_argument(
         "--clean-build",
         action="store_true",
-        help="Attempt to clean relevant build folders before repopulating")
+        help="Attempt to clean the entire build folder before building")
     parser.add_argument(
         "--cmake-exec",
         default="cmake",
@@ -162,26 +164,29 @@ def check_environment(args):
         dive.echo_and_run(cmd)
 
 
+def clean_build(args):
+    """Delete args.root_build_dir
+    """
+    if os.path.exists(f"{args.root_build_dir}"):
+        print("\nClearing build folder...")
+        shutil.rmtree(f"{args.root_build_dir}")
+
+
 def copy_plugins(args):
     """Implementing ActionType.COPY_PLUGINS stage
     """
-    if args.clean_build:
-        if os.path.exists(f"{args.root_build_dir}/pkg/plugins"):
-            print("\nClearing plugins folders...")
-            shutil.rmtree(f"{args.root_build_dir}/pkg/plugins")
+    if not os.path.exists(EXTERNAL_PLUGINS_DIR):
+        print(f"\nDir {EXTERNAL_PLUGINS_DIR} does not exist, skipping")
+        return
 
     print("\nCopying over external plugins...")
-    shutil.copytree("plugins/external", f"{args.root_build_dir}/pkg/plugins/", dirs_exist_ok=True)
+    print(os.listdir(EXTERNAL_PLUGINS_DIR))
+    shutil.copytree(EXTERNAL_PLUGINS_DIR, f"{args.root_build_dir}/pkg/plugins/", dirs_exist_ok=True)
 
 
 def configure_host(args):
     """Implementing ActionType.CONFIGURE_HOST stage
     """
-    if args.clean_build:
-        if os.path.exists(f"{args.root_build_dir}/host"):
-            print("\nClearing host build folders...")
-            shutil.rmtree(f"{args.root_build_dir}/host")
-
     print("\nGenerating build files with cmake...")
     if platform.system() in ["Linux", "Darwin"]:
         cmd = [args.cmake_exec, ".",
@@ -253,11 +258,6 @@ def install_host(args):
 def all_device(args):
     """Implementing ActionType.ALL_DEVICE stage
     """
-    if args.clean_build:
-        if os.path.exists(f"{args.root_build_dir}/device"):
-            print("\nClearing device build folders...")
-            shutil.rmtree(f"{args.root_build_dir}/device")
-
     print("\nGenerating build files with cmake...")
     android_ndk_home = os.environ["ANDROID_NDK_HOME"]
     cmd = [args.cmake_exec, ".",
@@ -316,7 +316,8 @@ def main():
         if not args.bypass_prereq_checks:
             print(f"\nChecking build environment...")
             check_environment(args)
-
+        if args.clean_build:
+            clean_build(args)
         if ActionType.COPY_PLUGINS in actions:
             with dive.Timer(ActionType.COPY_PLUGINS):
                 copy_plugins(args)


### PR DESCRIPTION
* Add copy_plugins action (for external plugins) to the build script
* `--clean-build` now applies at the beginning of the script and will clear the entire build folder