### PR TITLE
Make building host tools via CMake the default setting

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -72,6 +72,7 @@ jobs:
           python -u scripts/build.py \
             --actions configure_host,build_host,install_host \
             --build-type ${INPUTS_BUILD_TYPE} \
+            --build-via-generator \
             --ci \
             --host-configure-additional-flags "\
               -DDIVE_BUILD_WITH_CRASHPAD=OFF \

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -51,6 +51,7 @@ jobs:
           python -u scripts/build.py \
             --actions configure_host,build_host,install_host \
             --build-type ${INPUTS_BUILD_TYPE} \
+            --build-via-generator \
             --ci \
             --host-configure-additional-flags "\
               -DDIVE_BUILD_WITH_CRASHPAD=OFF \

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -29,6 +29,7 @@ jobs:
           python3 -u scripts/build.py `
             --actions configure_host,build_host,install_host `
             --build-type $env:INPUTS_BUILD_TYPE `
+            --build-via-generator `
             --ci `
             --host-configure-additional-flags "`
               -DDIVE_BUILD_WITH_CRASHPAD=OFF"

--- a/BUILD.md
+++ b/BUILD.md
@@ -101,9 +101,12 @@ This will run the default (entire) build process except for:
 TODO: b/484082504 - Add more stages for packaging and deploying to the unified build script
 
 ```sh
-# TIP: On Windows, run in Visual Studio Developer Command Prompt for VS 2022 (or 2019)
-
 python scripts/build.py
+
+# TIP: On Windows, run in Visual Studio Developer Command Prompt for VS 2022 (or 2019)
+#      and use --build-via-generator to build through VS and use multiple cores for speed
+
+python scripts/build.py --build-via-generator
 ```
 
 ### Custom Building Tips

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -60,9 +60,9 @@ def parse_args():
         choices=[x for x in BuildType],
         help="Build type for Dive (excluding GFXR gradle build which is always Debug)")
     parser.add_argument(
-        "--build-with-cmake",
+        "--build-via-generator",
         action="store_true",
-        help="Perform the build step by invoking cmake rather than the generator")
+        help="Perform the build step by invoking the generator rather than cmake, potentially faster on Windows platform")
     parser.add_argument(
         "--bypass-prereq-checks",
         action="store_true",
@@ -157,7 +157,7 @@ def check_environment(args):
     cmd = [args.ninja_exec, "--version"]
     dive.echo_and_run(cmd)
 
-    if (platform.system() == "Windows") and (not args.build_with_cmake):
+    if (platform.system() == "Windows") and (args.build_via_generator):
         cmd = [args.msbuild_exec, "--version"]
         dive.echo_and_run(cmd)
 
@@ -195,7 +195,7 @@ def configure_host(args):
 def build_host(args):
     """Implementing ActionType.BUILD_HOST stage
     """
-    if args.build_with_cmake:
+    if not args.build_via_generator:
         print("\nBuilding host libraries by invoking cmake...")
         cmd = [args.cmake_exec,
                "--build", f"{args.root_build_dir}/host",


### PR DESCRIPTION
Notes:
- Use default flags to build via `cmake`:
  - More convenient since we don't need to look for `msbuild` on path on Windows which may not exist depending on how VS was installed.
- Specify `--build-via-generator` to build through `msbuild`
  - Faster because multiple cores can be specified
- It's not straightforward to pass flags down from CMake to VS so that functionality is not supported in this PR