### PR TITLE
Initialize variables

### DIFF
--- a/dive_core/CMakeLists.txt
+++ b/dive_core/CMakeLists.txt
@@ -164,6 +164,7 @@ add_library(
     ${FREEDRENO_SRC_FILES}
     # Common
     common/common.h
+    common/common.cpp
     common/dive_capture_format.h
     common/emulate_pm4.cpp
     common/emulate_pm4.h
@@ -184,7 +185,6 @@ add_library(
     capture_event_info.h
     command_hierarchy.cpp
     command_hierarchy.h
-    common.cpp
     common.h
     conversions.h
     cross_ref.h

--- a/dive_core/common/common.cpp
+++ b/dive_core/common/common.cpp
@@ -15,17 +15,14 @@
  limitations under the License.
 */
 
-#include "common.h"
+#include "dive_core/common/common.h"
 
-#include <stdarg.h>
-
-#include <cerrno>
+#include <cstdarg>
 #include <cstdio>
-#include <cstring>
 
 void DIVE_LOG_INTERNAL(const char* file, int line, const char* format, ...)
 {
-    va_list args;
+    va_list args{};
     char str[8 * 1024];
     va_start(args, format);
     vsnprintf(str, sizeof(str), format, args);


### PR DESCRIPTION
The postsubmit run of clang-tidy was erroneously being run on the entire repo. However, this is the first run on the entire repo that was done on macOS and it ended up discovering this issue.

In addition, clean up some unused includes. Also, since this file defines a symbol declared in dive_core/common/common.h, I moved the file to dive_core/common/common.cpp so that it's more intuitively discoverable