### PR TITLE
Upgrade NDK to r29

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -44,7 +44,8 @@ jobs:
       - uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
         id: setup-ndk
         with:
-          ndk-version: r25
+          # TODO: b/504651150 - Prefer r30 (LTS) when it is relesed
+          ndk-version: r29
           add-to-path: true
       - name: (ccache) Clear stats
         run: ccache -z

--- a/BUILD.md
+++ b/BUILD.md
@@ -3,12 +3,15 @@
 - CMake
 - Ninja
 - The QT framework, can be installed from [QT online installer](https://download.qt.io/archive/online_installers/4.6/). We are currently using QT 5.15.2. Note that to install QT 5.15.2 from the online installer, you have to enable (turn on) the `archived` versions and then click on `filter`.
-- Android NDK (currently we are using 25.2.9519653).
+- Android NDK 29.0.14206865. You can get this fom https://developer.android.com/ndk/downloads or from the SDK package manager. If you have `sdkmanager` installed:
+  ```sh
+  sdkmanager --install "ndk;29.0.14206865"
+  ```
 - Python is installed with `python` in your PATH. It is recommended to use a virtual environment such as virtualenv or pipenv. Alternatively, on Debian, you can `sudo apt install python-is-python3`.
 - Mako Templates for Python: can be installed with following commandline
-    ```sh
-    pip install Mako
-    ```
+  ```sh
+  pip install Mako
+  ```
 - gfxreconstruct [dependencies](https://github.com/LunarG/gfxreconstruct/blob/dev/BUILD.md#android-development-requirements), if targetting Android. Specifically:
     - Android Studio. Make sure to install an SDK and accept the licenses.
     - On Linux, set up environment variables for building GFXReconstruct as explained [here](https://github.com/LunarG/gfxreconstruct/blob/dev/BUILD.md#additional-linux-command-linux-prerequisites)
@@ -31,7 +34,7 @@ Add permanently or per-session as desired.
 # Example setup
 
 # Android NDK prerequisite
-export ANDROID_NDK_HOME=~/android_sdk/ndk/25.2.9519653
+export ANDROID_NDK_HOME=~/Android/Sdk/ndk/29.0.14206865
 
 # gfxreconstruct prerequisite
 export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
@@ -53,7 +56,7 @@ export DIVE_ROOT_PATH=/path/to/dive
 REM Example setup
 
 REM Android NDK prerequisite
-set ANDROID_NDK_HOME=C:\Users\name\...\Android\Sdk\ndk\25.2.9519653
+set ANDROID_NDK_HOME=C:\Users\name\...\Android\Sdk\ndk\29.0.14206865
 
 REM gfxreconstruct prerequisite
 set JAVA_HOME=C:\Users\name\...\temurin-17.0.13
@@ -75,7 +78,7 @@ set DIVE_ROOT_PATH=C:\path\to\dive
 # Example setup
 
 # Android NDK prerequisite
-export ANDROID_NDK_HOME=~/Library/Android/sdk/ndk/25.2.9519653
+export ANDROID_NDK_HOME=~/Library/Android/sdk/ndk/29.0.14206865
 
 # gfxreconstruct prerequisite
 export JAVA_HOME=$(brew --prefix openjdk@17)/libexec/openjdk.jdk/Contents/Home


### PR DESCRIPTION
I had a choice between r27 (LTS), r29 (stable), and r30 (beta, soon-to-be LTS). I chose r29 since it will be closer to r30 when it's released. r30 is currently in beta so it's likely to release sooner than later.

Additionally, update the indentation for fenced code inside a list to align with examples provided by GitHub for GitHub Flavored Markdown: https://github.github.com/gfm/#example-298 . Notably, it uses a "hanging indent" of 2 spaces. This is rendered correctly in:

- the text diff viewer
- the rich diff viewer
- the final rendered file

Note that this doesn't impact the GFXR build. All GFXR build.gradle files use 26.3.11579264. This should only be an issue for Dive code that is built as part of the GFXR build (e.g. gfxr_decode_ext_lib, gpu_time).