### PR TITLE
Remove explicit strip of libwrap

### DIFF
--- a/third_party/freedreno/CMakeLists.txt
+++ b/third_party/freedreno/CMakeLists.txt
@@ -52,9 +52,4 @@ if(MSVC)
     set_target_properties(${target_name} PROPERTIES FOLDER "freedreno")
 endif()
 
-add_custom_command(TARGET ${target_name} POST_BUILD
-            COMMAND "${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-strip"  --strip-unneeded 
-            "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/lib${target_name}.so"
-            COMMENT "Strip debug symbols done on final binary.")
-
 install(TARGETS ${target_name} DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
Stripping prevents us from debugging issues: the debugger won't allow setting breakpoints, and we can't run ndk-stack to get line numbers. If stripping is desired, it should be taken care of by other CMake mechanisms that account for the build configuration.