### PR TITLE
Adds Option to  Skip App Setup

### DIFF
--- a/capture_service/device_mgr.cc
+++ b/capture_service/device_mgr.cc
@@ -645,7 +645,7 @@ absl::Status AndroidDevice::CleanupPackageProperties(const std::string& package)
 }
 
 absl::Status AndroidDevice::SetupApp(const std::string& package, const ApplicationType type,
-                                     const std::string& command_args)
+                                     const std::string& command_args, bool skip_app_setup)
 {
     if (type == ApplicationType::VULKAN_APK)
     {
@@ -672,6 +672,11 @@ absl::Status AndroidDevice::SetupApp(const std::string& package, const Applicati
     if (m_app == nullptr)
     {
         return absl::InternalError("Failed allocate memory for AndroidApplication");
+    }
+
+    if (skip_app_setup)
+    {
+        return absl::OkStatus();
     }
 
     m_app->SetGfxrCaptureSettings(m_gfxr_capture_settings);

--- a/capture_service/device_mgr.h
+++ b/capture_service/device_mgr.h
@@ -149,8 +149,11 @@ class AndroidDevice
     absl::StatusOr<std::vector<std::string>> ListPackage(
         PackageListOptions option = PackageListOptions::kAll) const;
     std::string GetDeviceDisplayName() const;
+
+    // If skip_app_setup is set to true, the application object is instantiated but standard ADB
+    // setup procedures are bypassed. This is used when applications require specialized setups.
     absl::Status SetupApp(const std::string& package, const ApplicationType type,
-                          const std::string& command_args);
+                          const std::string& command_args, bool skip_app_setup = false);
     absl::Status SetupApp(const std::string& binary, const std::string& args,
                           const ApplicationType type);
 


### PR DESCRIPTION
Adds Option to skip app setup. This is required for plugin use since the IsAppRunningOnForeground check was moved to AndroidApplication, requiring plugins to instantiate an AndroidApplication instance. The standard ADB
setup procedures are bypassed with this option enabled.