### PR TITLE
Fix PM4 capture path

### DIFF
--- a/third_party/freedreno/wrap/dive-wrap.c
+++ b/third_party/freedreno/wrap/dive-wrap.c
@@ -64,7 +64,7 @@ void SetCaptureState(int state)
                  DIVE_REPLAY_PM4_CAPTURE_FILE_NAME_PROPERTY_NAME,
                  prop_str);
 
-            snprintf(path, 1024, "/sdcard/Download/%s", prop_str);
+            snprintf(path, 1024, "/data/local/tmp/dive/%s", prop_str);
         }
         else
         {
@@ -76,7 +76,7 @@ void SetCaptureState(int state)
 
             const char* name = getenv("TESTNAME");
             if (!name)
-                name = "/sdcard/Download/trace-frame";
+                name = "/data/local/tmp/dive/trace-frame";
 
             snprintf(path, 1024, "%s-%04u.rd", name, frame_num);
         }


### PR DESCRIPTION
PM4 analysis of a capture is failing since the UI can't find the PM4 file.

PR #852 changed the path that the UI expects without changing the path that libwrap makes. This harmonizes the two.

This is a quick fix for the immediate issue. I'm going to spend more time on this issue and put up a better fix later.