### PR TITLE
Adds More Treeview Vulkan Command Info

### DIFF
--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -49,29 +49,147 @@ void GfxrVulkanCommandHierarchyCreator::ConditionallyAddChild(uint64_t node_inde
     }
 }
 
-//--------------------------------------------------------------------------------------------------
-std::string GfxrVulkanCommandHierarchyCreator::GetCurrDrawCallString()
+std::string GfxrVulkanCommandHierarchyCreator::GetValueStr(const nlohmann::ordered_json& node,
+                                                           const std::string& key)
 {
-    // Early return for zero instance count
-    if (m_cur_draw_call_info.instance_count == 0)
+    if (node.contains(key))
     {
-        return "";
+        const auto& val = node[key];
+        if (val.is_string())
+        {
+            return val.get<std::string>();
+        }
+        std::ostringstream s;
+        s << val;
+        return s.str();
     }
+    return "0";
+}
 
+void GfxrVulkanCommandHierarchyCreator::AppendDrawCallSummary(std::ostringstream& s,
+                                                              const nlohmann::ordered_json& args,
+                                                              const std::string& primary_key)
+{
+    if (args.contains(primary_key))
+    {
+        s << "(" << primary_key << ": " << GetValueStr(args, primary_key);
+        if (args.contains("instanceCount"))
+        {
+            std::string instance_count = GetValueStr(args, "instanceCount");
+            if (instance_count != "1")
+            {
+                s << ", instanceCount: " << instance_count;
+            }
+        }
+        s << ")";
+    }
+}
+
+void GfxrVulkanCommandHierarchyCreator::AppendEnumSummary(std::ostringstream& s,
+                                                          const nlohmann::ordered_json& args,
+                                                          const std::string& key,
+                                                          const std::string& prefix)
+{
+    if (args.contains(key))
+    {
+        std::string val = GetValueStr(args, key);
+        size_t prefix_pos = val.find(prefix);
+        if (prefix_pos != std::string::npos)
+        {
+            val.erase(prefix_pos, prefix.length());
+        }
+        s << "(" << val << ")";
+    }
+}
+
+std::string GfxrVulkanCommandHierarchyCreator::GetCommandSummary(const std::string& cmd_name,
+                                                                 const nlohmann::ordered_json& args)
+{
     std::ostringstream s;
 
-    s << "(";
-
-    if (m_cur_draw_call_info.index_count > 0)
+    if (cmd_name == "vkCmdDrawIndexed")
     {
-        s << "indexCount:" << m_cur_draw_call_info.index_count << ",";
+        AppendDrawCallSummary(s, args, "indexCount");
     }
-    else if (m_cur_draw_call_info.vertex_count > 0)
+    else if (cmd_name == "vkCmdDraw")
     {
-        s << "vertexCount:" << m_cur_draw_call_info.vertex_count << ",";
+        AppendDrawCallSummary(s, args, "vertexCount");
     }
-
-    s << "instanceCount:" << m_cur_draw_call_info.instance_count << ")";
+    else if (cmd_name == "vkCmdSetViewport")
+    {
+        if (args.contains("pViewports") && args["pViewports"].is_array() &&
+            !args["pViewports"].empty())
+        {
+            const auto& vp = args["pViewports"][0];
+            s << "(x:" << GetValueStr(vp, "x") << ", y:" << GetValueStr(vp, "y")
+              << ", width:" << GetValueStr(vp, "width") << ", height:" << GetValueStr(vp, "height")
+              << ")";
+        }
+    }
+    else if (cmd_name == "vkCmdSetScissor")
+    {
+        if (args.contains("pScissors") && args["pScissors"].is_array() &&
+            !args["pScissors"].empty())
+        {
+            const auto& sc = args["pScissors"][0];
+            if (sc.contains("offset") && sc.contains("extent"))
+            {
+                const auto& offset = sc["offset"];
+                const auto& extent = sc["extent"];
+                s << "(x:" << GetValueStr(offset, "x") << ", y:" << GetValueStr(offset, "y")
+                  << ", width:" << GetValueStr(extent, "width")
+                  << ", height:" << GetValueStr(extent, "height") << ")";
+            }
+        }
+    }
+    else if (cmd_name == "vkCmdDispatch")
+    {
+        if (args.contains("groupCountX"))
+        {
+            s << "(x:" << GetValueStr(args, "groupCountX")
+              << ", y:" << GetValueStr(args, "groupCountY")
+              << ", z:" << GetValueStr(args, "groupCountZ") << ")";
+        }
+    }
+    else if (cmd_name == "vkCmdDrawMultiEXT" || cmd_name == "vkCmdDrawMultiIndexedEXT")
+    {
+        AppendDrawCallSummary(s, args, "drawCount");
+    }
+    else if (cmd_name == "vkCmdDrawIndirect" || cmd_name == "vkCmdDrawIndexedIndirect")
+    {
+        if (args.contains("drawCount"))
+        {
+            std::string draw_count = GetValueStr(args, "drawCount");
+            if (draw_count != "1")
+            {
+                s << "(drawCount: " << draw_count << ")";
+            }
+        }
+    }
+    else if (cmd_name == "vkCmdBindPipeline")
+    {
+        AppendEnumSummary(s, args, "pipelineBindPoint", "VK_PIPELINE_BIND_POINT_");
+    }
+    else if (cmd_name == "vkCmdBindDescriptorSets")
+    {
+        if (args.contains("firstSet") && args.contains("descriptorSetCount"))
+        {
+            s << "(firstSet: " << GetValueStr(args, "firstSet")
+              << ", setCount: " << GetValueStr(args, "descriptorSetCount") << ")";
+        }
+    }
+    else if (cmd_name == "vkCmdBindVertexBuffers")
+    {
+        if (args.contains("firstBinding") && args.contains("bindingCount"))
+        {
+            s << "(firstBinding: " << GetValueStr(args, "firstBinding")
+              << ", bindingCount: " << GetValueStr(args, "bindingCount") << ")";
+        }
+    }
+    else if (cmd_name == "vkCmdBindIndexBuffer")
+    {
+        AppendEnumSummary(s, args, "indexType", "VK_INDEX_TYPE_");
+    }
 
     return s.str();
 }
@@ -85,6 +203,8 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
     const nlohmann::ordered_json& vulkan_cmd_args = vk_cmd_info.args;
     std::ostringstream vk_cmd_string_stream;
     vk_cmd_string_stream << vulkan_cmd_name;
+    vk_cmd_string_stream << GetCommandSummary(vulkan_cmd_name, vulkan_cmd_args);
+
     if (vulkan_cmd_name == "vkBeginCommandBuffer")
     {
         vk_cmd_string_stream << ", Draw Call Count: " << draw_call_count;
@@ -127,23 +247,10 @@ void GfxrVulkanCommandHierarchyCreator::OnCommand(
     else if (vulkan_cmd_name.find("vkCmdDraw") != std::string::npos ||
              vulkan_cmd_name.find("vkCmdDispatch") != std::string::npos)
     {
-        m_cur_draw_call_info = {};
-
         uint64_t vk_cmd_index =
             AddNode(NodeType::kGfxrVulkanDrawCommandNode, vk_cmd_string_stream.str());
         GetArgs(vulkan_cmd_args, vk_cmd_index);
         ConditionallyAddChild(vk_cmd_index);
-
-        if (vulkan_cmd_name.find("vkCmdDraw") != std::string::npos)
-        {
-            std::string extra_info = GetCurrDrawCallString();
-            if (!extra_info.empty())
-            {
-                // Update the draw node description with info obtained from its args
-                vk_cmd_string_stream << extra_info;
-                m_command_hierarchy.SetNodeDesc(vk_cmd_index, vk_cmd_string_stream.str());
-            }
-        }
     }
     else if (vulkan_cmd_name.find("vkCmdBeginRenderPass") != std::string::npos)
     {
@@ -326,44 +433,6 @@ void GfxrVulkanCommandHierarchyCreator::AddChild(CommandHierarchy::TopologyType 
     }
 }
 
-bool GfxrVulkanCommandHierarchyCreator::ParseCurDrawCallInfo(std::string_view key,
-                                                             std::string_view val)
-{
-    if (key == "indexCount")
-    {
-        uint64_t value = 0;
-        if (!absl::SimpleAtoi(val, &value))
-        {
-            return false;
-        }
-        m_cur_draw_call_info.index_count = value;
-        return true;
-    }
-    if (key == "vertexCount")
-    {
-        uint64_t value = 0;
-        if (!absl::SimpleAtoi(val, &value))
-        {
-            return false;
-        }
-        m_cur_draw_call_info.vertex_count = value;
-        return true;
-    }
-    if (key == "instanceCount")
-    {
-        uint64_t value = 0;
-        if (!absl::SimpleAtoi(val, &value))
-        {
-            return false;
-        }
-        m_cur_draw_call_info.instance_count = value;
-        return true;
-    }
-
-    // key is unrelated to DrawCallDescInfo
-    return true;
-}
-
 void GfxrVulkanCommandHierarchyCreator::GetArgs(const nlohmann::ordered_json& json_args,
                                                 uint64_t curr_index)
 {
@@ -434,12 +503,6 @@ void GfxrVulkanCommandHierarchyCreator::GetArgs(const nlohmann::ordered_json& js
 
                 s.str("");
                 s << key << ":" << val;
-
-                if (!ParseCurDrawCallInfo(key, val_str))
-                {
-                    std::cerr << "GfxrVulkanCommandHierarchyCreator::GetArgs() "
-                              << "could not parse draw call info from: " << s.str() << std::endl;
-                }
 
                 // If the value is a primitive,
                 // create a node containing the "key:value" pair.

--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -13,7 +13,10 @@
 
 #include "dive_core/gfxr_vulkan_command_hierarchy.h"
 
+#include <functional>
 #include <iostream>
+#include <string_view>
+#include <unordered_map>
 
 #include "absl/strings/numbers.h"
 #include "dive_core/dive_strings.h"
@@ -59,9 +62,7 @@ std::string GfxrVulkanCommandHierarchyCreator::GetValueStr(const nlohmann::order
         {
             return val.get<std::string>();
         }
-        std::ostringstream s;
-        s << val;
-        return s.str();
+        return val.dump();
     }
     return "0";
 }
@@ -107,88 +108,113 @@ std::string GfxrVulkanCommandHierarchyCreator::GetCommandSummary(const std::stri
 {
     std::ostringstream s;
 
-    if (cmd_name == "vkCmdDrawIndexed")
+    using SummaryHandler = std::function<void(GfxrVulkanCommandHierarchyCreator*,
+                                              std::ostringstream&, const nlohmann::ordered_json&)>;
+
+    static const std::unordered_map<std::string_view, SummaryHandler> handlers = {
+        {"vkCmdDrawIndexed",
+         [](auto* self, auto& s, const auto& args) {
+             self->AppendDrawCallSummary(s, args, "indexCount");
+         }},
+        {"vkCmdDraw",
+         [](auto* self, auto& s, const auto& args) {
+             self->AppendDrawCallSummary(s, args, "vertexCount");
+         }},
+        {"vkCmdSetViewport",
+         [](auto* self, auto& s, const auto& args) {
+             if (args.contains("pViewports") && args["pViewports"].is_array() &&
+                 !args["pViewports"].empty())
+             {
+                 const auto& vp = args["pViewports"][0];
+                 s << "(x:" << self->GetValueStr(vp, "x") << ", y:" << self->GetValueStr(vp, "y")
+                   << ", width:" << self->GetValueStr(vp, "width")
+                   << ", height:" << self->GetValueStr(vp, "height") << ")";
+             }
+         }},
+        {"vkCmdSetScissor",
+         [](auto* self, auto& s, const auto& args) {
+             if (args.contains("pScissors") && args["pScissors"].is_array() &&
+                 !args["pScissors"].empty())
+             {
+                 const auto& sc = args["pScissors"][0];
+                 if (sc.contains("offset") && sc.contains("extent"))
+                 {
+                     const auto& offset = sc["offset"];
+                     const auto& extent = sc["extent"];
+                     s << "(x:" << self->GetValueStr(offset, "x")
+                       << ", y:" << self->GetValueStr(offset, "y")
+                       << ", width:" << self->GetValueStr(extent, "width")
+                       << ", height:" << self->GetValueStr(extent, "height") << ")";
+                 }
+             }
+         }},
+        {"vkCmdDispatch",
+         [](auto* self, auto& s, const auto& args) {
+             if (args.contains("groupCountX"))
+             {
+                 s << "(x:" << self->GetValueStr(args, "groupCountX")
+                   << ", y:" << self->GetValueStr(args, "groupCountY")
+                   << ", z:" << self->GetValueStr(args, "groupCountZ") << ")";
+             }
+         }},
+        {"vkCmdDrawMultiEXT",
+         [](auto* self, auto& s, const auto& args) {
+             self->AppendDrawCallSummary(s, args, "drawCount");
+         }},
+        {"vkCmdDrawMultiIndexedEXT",
+         [](auto* self, auto& s, const auto& args) {
+             self->AppendDrawCallSummary(s, args, "drawCount");
+         }},
+        {"vkCmdDrawIndirect",
+         [](auto* self, auto& s, const auto& args) {
+             if (args.contains("drawCount"))
+             {
+                 std::string draw_count = self->GetValueStr(args, "drawCount");
+                 if (draw_count != "1")
+                 {
+                     s << "(drawCount: " << draw_count << ")";
+                 }
+             }
+         }},
+        {"vkCmdDrawIndexedIndirect",
+         [](auto* self, auto& s, const auto& args) {
+             if (args.contains("drawCount"))
+             {
+                 std::string draw_count = self->GetValueStr(args, "drawCount");
+                 if (draw_count != "1")
+                 {
+                     s << "(drawCount: " << draw_count << ")";
+                 }
+             }
+         }},
+        {"vkCmdBindPipeline",
+         [](auto* self, auto& s, const auto& args) {
+             self->AppendEnumSummary(s, args, "pipelineBindPoint", "VK_PIPELINE_BIND_POINT_");
+         }},
+        {"vkCmdBindDescriptorSets",
+         [](auto* self, auto& s, const auto& args) {
+             if (args.contains("firstSet") && args.contains("descriptorSetCount"))
+             {
+                 s << "(firstSet: " << self->GetValueStr(args, "firstSet")
+                   << ", setCount: " << self->GetValueStr(args, "descriptorSetCount") << ")";
+             }
+         }},
+        {"vkCmdBindVertexBuffers",
+         [](auto* self, auto& s, const auto& args) {
+             if (args.contains("firstBinding") && args.contains("bindingCount"))
+             {
+                 s << "(firstBinding: " << self->GetValueStr(args, "firstBinding")
+                   << ", bindingCount: " << self->GetValueStr(args, "bindingCount") << ")";
+             }
+         }},
+        {"vkCmdBindIndexBuffer", [](auto* self, auto& s, const auto& args) {
+             self->AppendEnumSummary(s, args, "indexType", "VK_INDEX_TYPE_");
+         }}};
+
+    auto it = handlers.find(std::string_view(cmd_name));
+    if (it != handlers.end())
     {
-        AppendDrawCallSummary(s, args, "indexCount");
-    }
-    else if (cmd_name == "vkCmdDraw")
-    {
-        AppendDrawCallSummary(s, args, "vertexCount");
-    }
-    else if (cmd_name == "vkCmdSetViewport")
-    {
-        if (args.contains("pViewports") && args["pViewports"].is_array() &&
-            !args["pViewports"].empty())
-        {
-            const auto& vp = args["pViewports"][0];
-            s << "(x:" << GetValueStr(vp, "x") << ", y:" << GetValueStr(vp, "y")
-              << ", width:" << GetValueStr(vp, "width") << ", height:" << GetValueStr(vp, "height")
-              << ")";
-        }
-    }
-    else if (cmd_name == "vkCmdSetScissor")
-    {
-        if (args.contains("pScissors") && args["pScissors"].is_array() &&
-            !args["pScissors"].empty())
-        {
-            const auto& sc = args["pScissors"][0];
-            if (sc.contains("offset") && sc.contains("extent"))
-            {
-                const auto& offset = sc["offset"];
-                const auto& extent = sc["extent"];
-                s << "(x:" << GetValueStr(offset, "x") << ", y:" << GetValueStr(offset, "y")
-                  << ", width:" << GetValueStr(extent, "width")
-                  << ", height:" << GetValueStr(extent, "height") << ")";
-            }
-        }
-    }
-    else if (cmd_name == "vkCmdDispatch")
-    {
-        if (args.contains("groupCountX"))
-        {
-            s << "(x:" << GetValueStr(args, "groupCountX")
-              << ", y:" << GetValueStr(args, "groupCountY")
-              << ", z:" << GetValueStr(args, "groupCountZ") << ")";
-        }
-    }
-    else if (cmd_name == "vkCmdDrawMultiEXT" || cmd_name == "vkCmdDrawMultiIndexedEXT")
-    {
-        AppendDrawCallSummary(s, args, "drawCount");
-    }
-    else if (cmd_name == "vkCmdDrawIndirect" || cmd_name == "vkCmdDrawIndexedIndirect")
-    {
-        if (args.contains("drawCount"))
-        {
-            std::string draw_count = GetValueStr(args, "drawCount");
-            if (draw_count != "1")
-            {
-                s << "(drawCount: " << draw_count << ")";
-            }
-        }
-    }
-    else if (cmd_name == "vkCmdBindPipeline")
-    {
-        AppendEnumSummary(s, args, "pipelineBindPoint", "VK_PIPELINE_BIND_POINT_");
-    }
-    else if (cmd_name == "vkCmdBindDescriptorSets")
-    {
-        if (args.contains("firstSet") && args.contains("descriptorSetCount"))
-        {
-            s << "(firstSet: " << GetValueStr(args, "firstSet")
-              << ", setCount: " << GetValueStr(args, "descriptorSetCount") << ")";
-        }
-    }
-    else if (cmd_name == "vkCmdBindVertexBuffers")
-    {
-        if (args.contains("firstBinding") && args.contains("bindingCount"))
-        {
-            s << "(firstBinding: " << GetValueStr(args, "firstBinding")
-              << ", bindingCount: " << GetValueStr(args, "bindingCount") << ")";
-        }
-    }
-    else if (cmd_name == "vkCmdBindIndexBuffer")
-    {
-        AppendEnumSummary(s, args, "indexType", "VK_INDEX_TYPE_");
+        it->second(this, s, args);
     }
 
     return s.str();
@@ -483,10 +509,8 @@ void GfxrVulkanCommandHierarchyCreator::GetArgs(const nlohmann::ordered_json& js
                     {
                         // If an array element is a primitive,
                         // create a node containing its string representation.
-                        std::ostringstream vk_cmd_arg_string_stream;
-                        vk_cmd_arg_string_stream << element;
-                        uint64_t arg_index = AddNode(NodeType::kGfxrVulkanCommandArgNode,
-                                                     vk_cmd_arg_string_stream.str());
+                        uint64_t arg_index =
+                            AddNode(NodeType::kGfxrVulkanCommandArgNode, element.dump());
                         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
                                  array_node_index, arg_index);
                     }
@@ -494,20 +518,10 @@ void GfxrVulkanCommandHierarchyCreator::GetArgs(const nlohmann::ordered_json& js
             }
             else
             {
-                std::ostringstream s;
-                std::string val_str;
-
-                s.str("");
-                s << val;
-                val_str = s.str();
-
-                s.str("");
-                s << key << ":" << val;
-
                 // If the value is a primitive,
                 // create a node containing the "key:value" pair.
-
-                uint64_t vk_cmd_arg_index = AddNode(NodeType::kGfxrVulkanCommandArgNode, s.str());
+                uint64_t vk_cmd_arg_index =
+                    AddNode(NodeType::kGfxrVulkanCommandArgNode, key + ":" + val.dump());
                 AddChild(CommandHierarchy::TopologyType::kAllEventTopology, curr_index,
                          vk_cmd_arg_index);
             }
@@ -528,10 +542,7 @@ void GfxrVulkanCommandHierarchyCreator::GetArgs(const nlohmann::ordered_json& js
             else
             {
                 // If an array element is a primitive, create a node for its string representation.
-                std::ostringstream vk_cmd_arg_string_stream;
-                vk_cmd_arg_string_stream << element;
-                uint64_t arg_index =
-                    AddNode(NodeType::kGfxrVulkanCommandArgNode, vk_cmd_arg_string_stream.str());
+                uint64_t arg_index = AddNode(NodeType::kGfxrVulkanCommandArgNode, element.dump());
                 AddChild(CommandHierarchy::TopologyType::kAllEventTopology, curr_index, arg_index);
             }
         }

--- a/dive_core/gfxr_vulkan_command_hierarchy.cpp
+++ b/dive_core/gfxr_vulkan_command_hierarchy.cpp
@@ -24,6 +24,171 @@
 namespace Dive
 {
 
+namespace
+{
+
+// Helper function to extract and convert a value associated with a specific
+// key from a JSON node into a string representation.
+std::string GetValueStr(const nlohmann::ordered_json& node, const std::string& key)
+{
+    if (node.contains(key))
+    {
+        const auto& val = node[key];
+        if (val.is_string())
+        {
+            return val.get<std::string>();
+        }
+        return val.dump();
+    }
+    return "0";
+}
+
+// Appends a summary of draw call arguments (vertex/index count, instance count) to the
+// given stream.
+void AppendDrawCallSummary(std::ostringstream& s, const nlohmann::ordered_json& args,
+                           const std::string& primary_key)
+{
+    if (args.contains(primary_key))
+    {
+        s << "(" << primary_key << ": " << GetValueStr(args, primary_key);
+        if (args.contains("instanceCount"))
+        {
+            std::string instance_count = GetValueStr(args, "instanceCount");
+            if (instance_count != "1")
+            {
+                s << ", instanceCount: " << instance_count;
+            }
+        }
+        s << ")";
+    }
+}
+
+// Appends a formatted enum value to the given stream, stripping a specified prefix if present.
+void AppendEnumSummary(std::ostringstream& s, const nlohmann::ordered_json& args,
+                       const std::string& key, const std::string& prefix)
+{
+    if (args.contains(key))
+    {
+        std::string val = GetValueStr(args, key);
+        size_t prefix_pos = val.find(prefix);
+        if (prefix_pos != std::string::npos)
+        {
+            val.erase(prefix_pos, prefix.length());
+        }
+        s << "(" << val << ")";
+    }
+}
+
+// Creates a summary string containing key arguments
+// and their values for a given Vulkan command.
+std::string GetCommandSummary(const std::string& cmd_name, const nlohmann::ordered_json& args)
+{
+    std::ostringstream s;
+
+    using SummaryHandler = std::function<void(std::ostringstream&, const nlohmann::ordered_json&)>;
+
+    static const std::unordered_map<std::string_view, SummaryHandler> handlers = {
+        {"vkCmdDrawIndexed",
+         [](auto& s, const auto& args) { AppendDrawCallSummary(s, args, "indexCount"); }},
+        {"vkCmdDraw",
+         [](auto& s, const auto& args) { AppendDrawCallSummary(s, args, "vertexCount"); }},
+        {"vkCmdSetViewport",
+         [](auto& s, const auto& args) {
+             if (args.contains("pViewports") && args["pViewports"].is_array() &&
+                 !args["pViewports"].empty())
+             {
+                 const auto& vp = args["pViewports"][0];
+                 s << "(x:" << GetValueStr(vp, "x") << ", y:" << GetValueStr(vp, "y")
+                   << ", width:" << GetValueStr(vp, "width")
+                   << ", height:" << GetValueStr(vp, "height") << ")";
+             }
+         }},
+        {"vkCmdSetScissor",
+         [](auto& s, const auto& args) {
+             if (args.contains("pScissors") && args["pScissors"].is_array() &&
+                 !args["pScissors"].empty())
+             {
+                 const auto& sc = args["pScissors"][0];
+                 if (sc.contains("offset") && sc.contains("extent"))
+                 {
+                     const auto& offset = sc["offset"];
+                     const auto& extent = sc["extent"];
+                     s << "(x:" << GetValueStr(offset, "x") << ", y:" << GetValueStr(offset, "y")
+                       << ", width:" << GetValueStr(extent, "width")
+                       << ", height:" << GetValueStr(extent, "height") << ")";
+                 }
+             }
+         }},
+        {"vkCmdDispatch",
+         [](auto& s, const auto& args) {
+             if (args.contains("groupCountX"))
+             {
+                 s << "(x:" << GetValueStr(args, "groupCountX")
+                   << ", y:" << GetValueStr(args, "groupCountY")
+                   << ", z:" << GetValueStr(args, "groupCountZ") << ")";
+             }
+         }},
+        {"vkCmdDrawMultiEXT",
+         [](auto& s, const auto& args) { AppendDrawCallSummary(s, args, "drawCount"); }},
+        {"vkCmdDrawMultiIndexedEXT",
+         [](auto& s, const auto& args) { AppendDrawCallSummary(s, args, "drawCount"); }},
+        {"vkCmdDrawIndirect",
+         [](auto& s, const auto& args) {
+             if (args.contains("drawCount"))
+             {
+                 std::string draw_count = GetValueStr(args, "drawCount");
+                 if (draw_count != "1")
+                 {
+                     s << "(drawCount: " << draw_count << ")";
+                 }
+             }
+         }},
+        {"vkCmdDrawIndexedIndirect",
+         [](auto& s, const auto& args) {
+             if (args.contains("drawCount"))
+             {
+                 std::string draw_count = GetValueStr(args, "drawCount");
+                 if (draw_count != "1")
+                 {
+                     s << "(drawCount: " << draw_count << ")";
+                 }
+             }
+         }},
+        {"vkCmdBindPipeline",
+         [](auto& s, const auto& args) {
+             AppendEnumSummary(s, args, "pipelineBindPoint", "VK_PIPELINE_BIND_POINT_");
+         }},
+        {"vkCmdBindDescriptorSets",
+         [](auto& s, const auto& args) {
+             if (args.contains("firstSet") && args.contains("descriptorSetCount"))
+             {
+                 s << "(firstSet: " << GetValueStr(args, "firstSet")
+                   << ", setCount: " << GetValueStr(args, "descriptorSetCount") << ")";
+             }
+         }},
+        {"vkCmdBindVertexBuffers",
+         [](auto& s, const auto& args) {
+             if (args.contains("firstBinding") && args.contains("bindingCount"))
+             {
+                 s << "(firstBinding: " << GetValueStr(args, "firstBinding")
+                   << ", bindingCount: " << GetValueStr(args, "bindingCount") << ")";
+             }
+         }},
+        {"vkCmdBindIndexBuffer", [](auto& s, const auto& args) {
+             AppendEnumSummary(s, args, "indexType", "VK_INDEX_TYPE_");
+         }}};
+
+    auto it = handlers.find(std::string_view(cmd_name));
+    if (it != handlers.end())
+    {
+        it->second(s, args);
+    }
+
+    return s.str();
+}
+
+}  // namespace
+
 // =================================================================================================
 // GfxrVulkanCommandHierarchyCreator
 // =================================================================================================
@@ -50,174 +215,6 @@ void GfxrVulkanCommandHierarchyCreator::ConditionallyAddChild(uint64_t node_inde
         AddChild(CommandHierarchy::TopologyType::kAllEventTopology,
                  m_cur_parent_node_index_stack.top(), node_index);
     }
-}
-
-std::string GfxrVulkanCommandHierarchyCreator::GetValueStr(const nlohmann::ordered_json& node,
-                                                           const std::string& key)
-{
-    if (node.contains(key))
-    {
-        const auto& val = node[key];
-        if (val.is_string())
-        {
-            return val.get<std::string>();
-        }
-        return val.dump();
-    }
-    return "0";
-}
-
-void GfxrVulkanCommandHierarchyCreator::AppendDrawCallSummary(std::ostringstream& s,
-                                                              const nlohmann::ordered_json& args,
-                                                              const std::string& primary_key)
-{
-    if (args.contains(primary_key))
-    {
-        s << "(" << primary_key << ": " << GetValueStr(args, primary_key);
-        if (args.contains("instanceCount"))
-        {
-            std::string instance_count = GetValueStr(args, "instanceCount");
-            if (instance_count != "1")
-            {
-                s << ", instanceCount: " << instance_count;
-            }
-        }
-        s << ")";
-    }
-}
-
-void GfxrVulkanCommandHierarchyCreator::AppendEnumSummary(std::ostringstream& s,
-                                                          const nlohmann::ordered_json& args,
-                                                          const std::string& key,
-                                                          const std::string& prefix)
-{
-    if (args.contains(key))
-    {
-        std::string val = GetValueStr(args, key);
-        size_t prefix_pos = val.find(prefix);
-        if (prefix_pos != std::string::npos)
-        {
-            val.erase(prefix_pos, prefix.length());
-        }
-        s << "(" << val << ")";
-    }
-}
-
-std::string GfxrVulkanCommandHierarchyCreator::GetCommandSummary(const std::string& cmd_name,
-                                                                 const nlohmann::ordered_json& args)
-{
-    std::ostringstream s;
-
-    using SummaryHandler = std::function<void(GfxrVulkanCommandHierarchyCreator*,
-                                              std::ostringstream&, const nlohmann::ordered_json&)>;
-
-    static const std::unordered_map<std::string_view, SummaryHandler> handlers = {
-        {"vkCmdDrawIndexed",
-         [](auto* self, auto& s, const auto& args) {
-             self->AppendDrawCallSummary(s, args, "indexCount");
-         }},
-        {"vkCmdDraw",
-         [](auto* self, auto& s, const auto& args) {
-             self->AppendDrawCallSummary(s, args, "vertexCount");
-         }},
-        {"vkCmdSetViewport",
-         [](auto* self, auto& s, const auto& args) {
-             if (args.contains("pViewports") && args["pViewports"].is_array() &&
-                 !args["pViewports"].empty())
-             {
-                 const auto& vp = args["pViewports"][0];
-                 s << "(x:" << self->GetValueStr(vp, "x") << ", y:" << self->GetValueStr(vp, "y")
-                   << ", width:" << self->GetValueStr(vp, "width")
-                   << ", height:" << self->GetValueStr(vp, "height") << ")";
-             }
-         }},
-        {"vkCmdSetScissor",
-         [](auto* self, auto& s, const auto& args) {
-             if (args.contains("pScissors") && args["pScissors"].is_array() &&
-                 !args["pScissors"].empty())
-             {
-                 const auto& sc = args["pScissors"][0];
-                 if (sc.contains("offset") && sc.contains("extent"))
-                 {
-                     const auto& offset = sc["offset"];
-                     const auto& extent = sc["extent"];
-                     s << "(x:" << self->GetValueStr(offset, "x")
-                       << ", y:" << self->GetValueStr(offset, "y")
-                       << ", width:" << self->GetValueStr(extent, "width")
-                       << ", height:" << self->GetValueStr(extent, "height") << ")";
-                 }
-             }
-         }},
-        {"vkCmdDispatch",
-         [](auto* self, auto& s, const auto& args) {
-             if (args.contains("groupCountX"))
-             {
-                 s << "(x:" << self->GetValueStr(args, "groupCountX")
-                   << ", y:" << self->GetValueStr(args, "groupCountY")
-                   << ", z:" << self->GetValueStr(args, "groupCountZ") << ")";
-             }
-         }},
-        {"vkCmdDrawMultiEXT",
-         [](auto* self, auto& s, const auto& args) {
-             self->AppendDrawCallSummary(s, args, "drawCount");
-         }},
-        {"vkCmdDrawMultiIndexedEXT",
-         [](auto* self, auto& s, const auto& args) {
-             self->AppendDrawCallSummary(s, args, "drawCount");
-         }},
-        {"vkCmdDrawIndirect",
-         [](auto* self, auto& s, const auto& args) {
-             if (args.contains("drawCount"))
-             {
-                 std::string draw_count = self->GetValueStr(args, "drawCount");
-                 if (draw_count != "1")
-                 {
-                     s << "(drawCount: " << draw_count << ")";
-                 }
-             }
-         }},
-        {"vkCmdDrawIndexedIndirect",
-         [](auto* self, auto& s, const auto& args) {
-             if (args.contains("drawCount"))
-             {
-                 std::string draw_count = self->GetValueStr(args, "drawCount");
-                 if (draw_count != "1")
-                 {
-                     s << "(drawCount: " << draw_count << ")";
-                 }
-             }
-         }},
-        {"vkCmdBindPipeline",
-         [](auto* self, auto& s, const auto& args) {
-             self->AppendEnumSummary(s, args, "pipelineBindPoint", "VK_PIPELINE_BIND_POINT_");
-         }},
-        {"vkCmdBindDescriptorSets",
-         [](auto* self, auto& s, const auto& args) {
-             if (args.contains("firstSet") && args.contains("descriptorSetCount"))
-             {
-                 s << "(firstSet: " << self->GetValueStr(args, "firstSet")
-                   << ", setCount: " << self->GetValueStr(args, "descriptorSetCount") << ")";
-             }
-         }},
-        {"vkCmdBindVertexBuffers",
-         [](auto* self, auto& s, const auto& args) {
-             if (args.contains("firstBinding") && args.contains("bindingCount"))
-             {
-                 s << "(firstBinding: " << self->GetValueStr(args, "firstBinding")
-                   << ", bindingCount: " << self->GetValueStr(args, "bindingCount") << ")";
-             }
-         }},
-        {"vkCmdBindIndexBuffer", [](auto* self, auto& s, const auto& args) {
-             self->AppendEnumSummary(s, args, "indexType", "VK_INDEX_TYPE_");
-         }}};
-
-    auto it = handlers.find(std::string_view(cmd_name));
-    if (it != handlers.end())
-    {
-        it->second(this, s, args);
-    }
-
-    return s.str();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/dive_core/gfxr_vulkan_command_hierarchy.h
+++ b/dive_core/gfxr_vulkan_command_hierarchy.h
@@ -77,23 +77,6 @@ class GfxrVulkanCommandHierarchyCreator
                   uint64_t child_node_index);
     void ConditionallyAddChild(uint64_t node_index);
 
-    // Helper function to extract and convert a value associated with a specific
-    // key from a JSON node into a string representation.
-    std::string GetValueStr(const nlohmann::ordered_json& node, const std::string& key);
-
-    // Creates a summary string containing key arguments
-    // and their values for a given Vulkan command.
-    std::string GetCommandSummary(const std::string& cmd_name, const nlohmann::ordered_json& args);
-
-    // Appends a summary of draw call arguments (vertex/index count, instance count) to the
-    // given stream.
-    void AppendDrawCallSummary(std::ostringstream& stream, const nlohmann::ordered_json& args,
-                               const std::string& primary_key);
-
-    // Appends a formatted enum value to the given stream, stripping a specified prefix if present.
-    void AppendEnumSummary(std::ostringstream& stream, const nlohmann::ordered_json& args,
-                           const std::string& key, const std::string& prefix);
-
     uint64_t m_cur_submit_node_index = 0;
     uint64_t m_cur_command_buffer_node_index = 0;
     std::stack<uint64_t> m_cur_parent_node_index_stack;

--- a/dive_core/gfxr_vulkan_command_hierarchy.h
+++ b/dive_core/gfxr_vulkan_command_hierarchy.h
@@ -77,6 +77,23 @@ class GfxrVulkanCommandHierarchyCreator
                   uint64_t child_node_index);
     void ConditionallyAddChild(uint64_t node_index);
 
+    // Helper function to extract and convert a value associated with a specific
+    // key from a JSON node into a string representation.
+    std::string GetValueStr(const nlohmann::ordered_json& node, const std::string& key);
+
+    // Creates a summary string containing key arguments
+    // and their values for a given Vulkan command.
+    std::string GetCommandSummary(const std::string& cmd_name, const nlohmann::ordered_json& args);
+
+    // Appends a summary of draw call arguments (vertex/index count, instance count) to the
+    // given stream.
+    void AppendDrawCallSummary(std::ostringstream& stream, const nlohmann::ordered_json& args,
+                               const std::string& primary_key);
+
+    // Appends a formatted enum value to the given stream, stripping a specified prefix if present.
+    void AppendEnumSummary(std::ostringstream& stream, const nlohmann::ordered_json& args,
+                           const std::string& key, const std::string& prefix);
+
     uint64_t m_cur_submit_node_index = 0;
     uint64_t m_cur_command_buffer_node_index = 0;
     std::stack<uint64_t> m_cur_parent_node_index_stack;
@@ -88,27 +105,5 @@ class GfxrVulkanCommandHierarchyCreator
     Topology m_topology[CommandHierarchy::kTopologyTypeCount];
     bool m_used_in_mixed_command_hierarchy = false;
     std::unordered_map<uint64_t, uint64_t> m_dive_indices_to_local_indices_map;
-
-    // Additional info that will be displayed in the description of a draw call node
-    struct DrawCallDescInfo
-    {
-        uint64_t index_count = 0;
-        uint64_t vertex_count = 0;
-        uint64_t instance_count = 0;
-    };
-
-    // Returns false if key was recognized to correspond to a DrawCallDescInfo field but val could
-    // not be parsed
-    bool ParseCurDrawCallInfo(std::string_view key, std::string_view val);
-
-    // Forms string of drawcall info, some examples:
-    //
-    // vkCmdDraw: "(vertexCount=#,instanceCount=#)"
-    // vkCmdDrawIndexed: "(indexCount=#,instanceCount=#)"
-    // vkCmdDrawMultiEXT: "(instanceCount=#)"
-    // vkCmdDraw* without instanceCount parameter: ""
-    std::string GetCurrDrawCallString();
-
-    DrawCallDescInfo m_cur_draw_call_info;
 };
 }  // namespace Dive


### PR DESCRIPTION
Adds more vulkan command info visible in the gfxr tree view. For draw calls, the instance count is displayed when the count is greater than 1. 
<img width="465" height="514" alt="Screenshot 2026-04-28 at 2 56 37 PM" src="https://github.com/user-attachments/assets/8b9b713d-b96e-465a-8075-3f30f023f2cc" />

<img width="612" height="154" alt="Screenshot 2026-04-30 at 9 23 31 AM" src="https://github.com/user-attachments/assets/c4e67a57-0f2a-48a1-9df3-580f486c6a9b" />



