### PR TITLE
[libwrap] Modernize CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,9 +186,7 @@ else()
         "Generate build files for third_party/freedreno (libwrap)"
     )
     list(APPEND CMAKE_MESSAGE_INDENT "  ")
-    # Currently hardcoding debug build, unknown reason
-    add_subdirectory(third_party/freedreno EXCLUDE_FROM_ALL)
-    install(TARGETS wrap DESTINATION "${DIVE_INSTALL_DEST_DEVICE}")
+    add_subdirectory(third_party/freedreno)
     list(POP_BACK CMAKE_MESSAGE_INDENT)
     message(CHECK_PASS "done")
 

--- a/scripts/format_cmake.bat
+++ b/scripts/format_cmake.bat
@@ -30,6 +30,7 @@ network ^
 plugins ^
 runtime_layer ^
 third_party/dive_crashpad ^
+third_party/freedreno ^
 trace_stats ^
 ui ^
 src

--- a/scripts/format_cmake.sh
+++ b/scripts/format_cmake.sh
@@ -31,6 +31,7 @@ SRC_DIRS=(
     "plugins"
     "runtime_layer"
     "third_party/dive_crashpad"
+    "third_party/freedreno"
     "trace_stats"
     "ui"
     "src"

--- a/third_party/freedreno/CMakeLists.txt
+++ b/third_party/freedreno/CMakeLists.txt
@@ -14,42 +14,15 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.5)
-project(libwrap)
-set(target_name wrap)
+# Freedreno can be compiled on its own; keep the version and project info.
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+project(wrap C CXX)
 
 if(NOT ANDROID)
-    message( FATAL_ERROR "libwrap can only works on Android." )
+    message(FATAL_ERROR "Dive only supports libwrap for Android.")
 endif()
 
-message("Build libwrap for Android")
-set(HDR_FILES  "${CMAKE_CURRENT_SOURCE_DIR}/wrap/list.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/wrap/wrap.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/wrap/dive-wrap.h"
-)
+add_library(freedreno_includes INTERFACE)
+target_include_directories(freedreno_includes INTERFACE includes util)
 
-set(SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/wrap/wrap-util.c"
-    "${CMAKE_CURRENT_SOURCE_DIR}/wrap/wrap-syscall.c"
-    "${CMAKE_CURRENT_SOURCE_DIR}/wrap/dive-load-status.cc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/wrap/dive-wrap.c"
-)
-
-add_library(wrap SHARED ${HDR_FILES} ${SRC_FILES})
-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -frtti -fexceptions")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -DBIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD")
-add_definitions(-DANDROID_STL=c++_shared -DNDK_DEBUG=1 -DBIONIC=1)
-set(CMAKE_BUILD_TYPE Debug)  # Release build didn't work (TODO: check why release build not working)
-target_include_directories(${target_name} 
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/includes
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/util)
-target_link_libraries(${target_name} log z)
-set_target_properties(${target_name}
-    PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"
-)
-
-if(MSVC)
-    set_target_properties(${target_name} PROPERTIES FOLDER "freedreno")
-endif()
-
-install(TARGETS ${target_name} DESTINATION ${CMAKE_INSTALL_PREFIX})
+add_subdirectory(wrap)

--- a/third_party/freedreno/CMakeLists.txt
+++ b/third_party/freedreno/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 # Freedreno can be compiled on its own; keep the version and project info.
 cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
-project(wrap C CXX)
+project(freedreno C CXX)
 
 if(NOT ANDROID)
     message(FATAL_ERROR "Dive only supports libwrap for Android.")

--- a/third_party/freedreno/CMakeLists.txt
+++ b/third_party/freedreno/CMakeLists.txt
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-# Freedreno can be compiled on its own; keep the version and project info.
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
-project(freedreno C CXX)
-
 if(NOT ANDROID)
     message(FATAL_ERROR "Dive only supports Freedreno for Android.")
 endif()

--- a/third_party/freedreno/CMakeLists.txt
+++ b/third_party/freedreno/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project(freedreno C CXX)
 
 if(NOT ANDROID)
-    message(FATAL_ERROR "Dive only supports libwrap for Android.")
+    message(FATAL_ERROR "Dive only supports Freedreno for Android.")
 endif()
 
 add_library(freedreno_includes INTERFACE)

--- a/third_party/freedreno/wrap/CMakeLists.txt
+++ b/third_party/freedreno/wrap/CMakeLists.txt
@@ -1,0 +1,49 @@
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add_library(
+    wrap
+    SHARED
+    dive-load-status.cc
+    dive-wrap.c
+    dive-wrap.h
+    list.h
+    wrap-syscall.c
+    wrap-util.c
+    wrap.h
+)
+target_link_libraries(wrap PRIVATE freedreno_includes log z)
+# TODO: b/505831929 - Figure out which options are required
+# _FORTIFY_SOURCE can likely go in target_compile_definitions however it was
+# unclear to me if the #undef is necessary and whether or not we need to ensure
+# it is first on the command-line.
+target_compile_options(
+    wrap
+    PRIVATE -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
+)
+target_compile_definitions(
+    wrap
+    PRIVATE BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD ANDROID_STL=c++_shared BIONIC=1
+)
+
+set_target_properties(
+    wrap
+    PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"
+        FOLDER "freedreno"
+)
+
+install(TARGETS wrap DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/third_party/freedreno/wrap/CMakeLists.txt
+++ b/third_party/freedreno/wrap/CMakeLists.txt
@@ -30,10 +30,7 @@ target_link_libraries(wrap PRIVATE freedreno_includes log z)
 # _FORTIFY_SOURCE can likely go in target_compile_definitions however it was
 # unclear to me if the #undef is necessary and whether or not we need to ensure
 # it is first on the command-line.
-target_compile_options(
-    wrap
-    PRIVATE -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
-)
+target_compile_options(wrap PRIVATE -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0)
 target_compile_definitions(
     wrap
     PRIVATE BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD ANDROID_STL=c++_shared BIONIC=1

--- a/third_party/freedreno/wrap/CMakeLists.txt
+++ b/third_party/freedreno/wrap/CMakeLists.txt
@@ -36,11 +36,6 @@ target_compile_definitions(
     PRIVATE BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD ANDROID_STL=c++_shared BIONIC=1
 )
 
-set_target_properties(
-    wrap
-    PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"
-        FOLDER "freedreno"
-)
+set_target_properties(wrap PROPERTIES FOLDER "freedreno")
 
-install(TARGETS wrap DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(TARGETS wrap DESTINATION "${DIVE_INSTALL_DEST_DEVICE}")


### PR DESCRIPTION
Given recent problems with libwrap, I've attempted to rewrite the CMakeLists to improve clarity and readability

- Remove project and cmake_minimum_required since this is integrated with the Dive compile.
- Collapse two installs into one. Removed EXCLUDE_FROM_ALL since we want to build and install Freedreno (only libwrap and we control the CMakeLists)
- Remove use of variables since they are unnecessary and error-prone
- Replace CMAKE_C_FLAGS and CMAKE_CPP_FLAGS with target_compile_options() and target_compile_definitions().
- Remove -frtti and -fexceptions since there's no C++ code that uses these features. Additionally, they weren't being used in the first place since CMAKE_CPP_FLAGS is not a real var; removing them now doesn't change how libwrap is being built.
- Remove -DNDK_DEBUG=1 since it's only used by ndk-build (not CMake)
- Define common includes as a target and include the target as a dependency. This way, the same set of includes can be reused trivially in the future.
- Remove CMAKE_BUILD_TYPE override since it doesn't do anything for multi-config generators (and I may have fixed the problem)
- Collapse multiple set_target_properties calls into one. The if(MSVC) is likely unnecessary since FOLDERS is ignored for generators that don't support it.
- Create a second CMakeLists.txt inside the wrap folder to reduce the amount of typing for source files. We own the CMakeLists.txt files so this likely shouldn't create conflicts in the future.

Additionally--since we own those CMake files--run gersemi on them