### PR TITLE
setenforce 0 for GFXR capture

### DIFF
--- a/capture_service/android_application.cc
+++ b/capture_service/android_application.cc
@@ -519,6 +519,10 @@ absl::Status AndroidApplication::GfxrSetup()
             "Called GfxrSetup without calling SetGfxrCaptureSettings first!");
     }
 
+    // Need setenforce 0 to save files to /data/local/tmp
+    // TODO: b/506157883 - Make kDeviceDownloadPath user-configurable and remove need for root
+    RETURN_IF_ERROR(m_dev.RequestRootAccess());
+
     LOG(INFO) << "AndroidApplication::GfxrSetup() package " << m_package << " started";
     RETURN_IF_ERROR(
         m_dev.DeployDeviceResource(Dive::DeviceResourcesConstants::kVkGfxrLayerLibName));


### PR DESCRIPTION
PR #852 broke non-OpenXR Vulkan capture.

Saving to /data/local/tmp requires setenforce 0. Currently, OpenXR runs `setenforce 0` (even though it doesn't need to) but Vulkan apps don't.

The real fix is to make this directory user-configurable and remove any unnecessary root requirements. I have created a separate bug for that.