### PR TITLE
Share device download path between C and C++

### DIFF
--- a/src/dive/utils/device_resources_constants.h
+++ b/src/dive/utils/device_resources_constants.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #include <string_view>
 
+#include "dive/utils/device_resources_constants_defines.h"
+
 namespace Dive
 {
 
@@ -93,7 +95,7 @@ Profiling resources dir:    DIVE_ROOT/build/pkg/CMAKE_GENERATED_PROFILING_PLUGIN
     static constexpr size_t kMaxSetPropLength = 92;
 
     // The absolute path to the standard Download directory on Android.
-    static constexpr char kDeviceDownloadPath[] = "/data/local/tmp/dive";
+    static constexpr char kDeviceDownloadPath[] = DIVE_DEVICE_DOWNLOAD_PATH;
     // The name of the temporary staging directory created on the device.
     static constexpr char kDeviceStagingDirectoryName[] = "out";
     // The default name for GFXR capture files when the original name is too long.

--- a/src/dive/utils/device_resources_constants_defines.h
+++ b/src/dive/utils/device_resources_constants_defines.h
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+// This file is #included by both C and C++ code. This facilitates sharing
+// between libwrap and Dive.
+
+#define DIVE_DEVICE_DOWNLOAD_PATH "/data/local/tmp/dive"

--- a/third_party/freedreno/wrap/CMakeLists.txt
+++ b/third_party/freedreno/wrap/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(
     wrap-util.c
     wrap.h
 )
-target_link_libraries(wrap PRIVATE freedreno_includes log z)
+target_link_libraries(wrap PRIVATE freedreno_includes dive_src_includes log z)
 # TODO: b/505831929 - Figure out which options are required
 # _FORTIFY_SOURCE can likely go in target_compile_definitions however it was
 # unclear to me if the #undef is necessary and whether or not we need to ensure

--- a/third_party/freedreno/wrap/dive-wrap.c
+++ b/third_party/freedreno/wrap/dive-wrap.c
@@ -21,6 +21,8 @@ limitations under the License.
 #include <string.h>
 #include <sys/system_properties.h>
 
+#include "dive/utils/device_resources_constants_defines.h"
+
 // TODO: (renfeng) update the capture interface so that user can set this property value.
 #define DIVE_MAX_BUFFER_SIZE_PROPERTY_NAME "debug.dive.pm4.max_buffer_size"
 #define DIVE_REPLAY_PM4_CAPTURE_PROPERTY_NAME "debug.dive.replay.capture_pm4"
@@ -64,7 +66,7 @@ void SetCaptureState(int state)
                  DIVE_REPLAY_PM4_CAPTURE_FILE_NAME_PROPERTY_NAME,
                  prop_str);
 
-            snprintf(path, 1024, "/data/local/tmp/dive/%s", prop_str);
+            snprintf(path, 1024, DIVE_DEVICE_DOWNLOAD_PATH "/%s", prop_str);
         }
         else
         {
@@ -76,7 +78,7 @@ void SetCaptureState(int state)
 
             const char* name = getenv("TESTNAME");
             if (!name)
-                name = "/data/local/tmp/dive/trace-frame";
+                name = DIVE_DEVICE_DOWNLOAD_PATH "/trace-frame";
 
             snprintf(path, 1024, "%s-%04u.rd", name, frame_num);
         }

--- a/third_party/freedreno/wrap/wrap-util.c
+++ b/third_party/freedreno/wrap/wrap-util.c
@@ -25,6 +25,7 @@
 
 // GOOGLE: Include Dive related header
 #include "dive-wrap.h"
+#include "dive/utils/device_resources_constants_defines.h"
 
 int IsCapturing();
 #include <ctype.h>
@@ -198,7 +199,8 @@ void rd_start(int device_fd, const char *name, const char *fmt, ...)
 	}
 
 #if defined(BIONIC)
-	char* base_path = "/sdcard/Download";
+	// GOOGLE: Use the same path as Dive since we know that we can write to it.
+	char* base_path = DIVE_DEVICE_DOWNLOAD_PATH;
 #else
 	char* base_path = "/tmp";
 #endif


### PR DESCRIPTION
Having this constant defined once and shared across the repo reduces the amount of bugs like PR #862