### PR TITLE
Define DIVE_DEPLOY_FOLDER_PATH in CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ if(UPLOAD_DEBUG_SYMBOLS)
     endif()
 endif()
 
+set(DIVE_DEPLOY_FOLDER_PATH /data/local/tmp/dive)
+
 # Disable gtest for install
 set(INSTALL_GTEST OFF)
 

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -93,16 +93,7 @@ set_target_properties(
     ${target_name}
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"
 )
-configure_file(
-    "manifest/XrApiLayer_dive.json"
-    "${CMAKE_BINARY_DIR}/bin/VkLayer_dive_capture.json"
-    COPYONLY
-)
 install(TARGETS ${target_name} DESTINATION "${DIVE_DEST_DEVICE}")
-install(
-    FILES "${CMAKE_CURRENT_SOURCE_DIR}/manifest/XrApiLayer_dive.json"
-    DESTINATION "${DIVE_DEST_DEVICE}"
-)
 
 set(target_name XrApiLayer_dive)
 set(XR_LAYER_SRC_FILES
@@ -129,8 +120,10 @@ endif()
 target_link_libraries(${target_name} ${TARGET_LINK_LIBS})
 
 install(TARGETS ${target_name} DESTINATION "${DIVE_DEST_DEVICE}")
+
+configure_file(manifest/XrApiLayer_dive.json.in manifest/XrApiLayer_dive.json)
 install(
-    FILES "${CMAKE_CURRENT_SOURCE_DIR}/manifest/XrApiLayer_dive.json"
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/manifest/XrApiLayer_dive.json"
     DESTINATION "${DIVE_DEST_DEVICE}"
 )
 

--- a/layer/manifest/XrApiLayer_dive.json.in
+++ b/layer/manifest/XrApiLayer_dive.json.in
@@ -2,7 +2,7 @@
     "file_format_version": "1.0.0",
     "api_layer": {
         "name": "XR_APILAYER_dive",
-        "library_path": "/data/local/tmp/dive/libXrApiLayer_dive.so",
+        "library_path": "@DIVE_DEPLOY_FOLDER_PATH@/libXrApiLayer_dive.so",
         "api_version": "1.0",
         "implementation_version": "1",
         "description": "API Layer to record api calls as they occur",


### PR DESCRIPTION
Use it to generate the OpenXR loader config JSON file. In the future,
this will also be used by C/C++ code. The goal is to reduce duplication
and ensure that all features still work when the variable is updated.

Additionally, remove redundant install() command.