### PR TITLE
Package libwrap into GFXR replay

### DIFF
--- a/capture_service/device_mgr.cc
+++ b/capture_service/device_mgr.cc
@@ -542,6 +542,7 @@ absl::Status AndroidDevice::SetupDevice()
 
     if (!m_gfxr_capture_settings)
     {
+        // TODO: b/506128425 - We shouldn't need root for replay
         RETURN_IF_ERROR(RequestRootAccess());
         RETURN_IF_ERROR(DeployDeviceResource(Dive::DeviceResourcesConstants::kVkLayerLibName));
         RETURN_IF_ERROR(DeployDeviceResource(Dive::DeviceResourcesConstants::kXrLayerLibName));

--- a/third_party/freedreno/wrap/CMakeLists.txt
+++ b/third_party/freedreno/wrap/CMakeLists.txt
@@ -25,7 +25,9 @@ add_library(
     wrap-util.c
     wrap.h
 )
-target_link_libraries(wrap PRIVATE freedreno_includes dive_src_includes log z)
+target_link_libraries(wrap PRIVATE freedreno_includes log z)
+# Could use dive_src_includes but the GFXR build doesn't have it defined.
+target_include_directories(wrap PRIVATE ../../../src)
 # TODO: b/505831929 - Figure out which options are required
 # _FORTIFY_SOURCE can likely go in target_compile_definitions however it was
 # unclear to me if the #undef is necessary and whether or not we need to ensure

--- a/third_party/gfxreconstruct/android/tools/replay/CMakeLists.txt
+++ b/third_party/gfxreconstruct/android/tools/replay/CMakeLists.txt
@@ -23,6 +23,9 @@ add_subdirectory(../../framework/application ${PROJECT_SOURCE_DIR}/../../framewo
 # GOOGLE: Add subdirectories for gfxr_ext, putting binaries into the same dir as their base counterparts
 add_subdirectory(../../../../../gfxr_ext/decode ${CMAKE_SOURCE_DIR}/../../framework/decode_ext/build/tools/replay/${ANDROID_ABI})
 
+# GOOGLE: Package libwrap into replay to simplify deployment
+add_subdirectory(../../../../freedreno ${CMAKE_SOURCE_DIR}/../../framework/freedreno/build/tools/replay/${ANDROID_ABI})
+
 add_library(gfxrecon-replay
             SHARED
                 ${GFXRECON_SOURCE_DIR}/tools/tool_settings.h

--- a/third_party/gfxreconstruct/android/tools/replay/src/main/resources/lib/arm64-v8a/wrap.sh
+++ b/third_party/gfxreconstruct/android/tools/replay/src/main/resources/lib/arm64-v8a/wrap.sh
@@ -35,7 +35,7 @@ fi
 
 echo "capture_pm4_enabled is " $capture_pm4_enabled
 if [[ "$capture_pm4_enabled" == "true" || "$capture_pm4_enabled" == "1" ]]; then
-    export LD_PRELOAD=/data/local/tmp/dive/libwrap.so
+    export LD_PRELOAD="$(dirname $0)/libwrap.so"
 fi
 
 exec $cmd


### PR DESCRIPTION
In my quest to remove hardcoded paths that are copy-pasted in multiple locations, I found that wrap.sh can refer to binaries packaged inside the application. By packaging libwrap into the replay, we

- simplify deployment: don't need to push libwrap.so. This will be tackled in a later PR.
- improve compatibility: theoretically don't need root access anymore for replay with PM4 dump. This will be tackled in a later PR.
- improve maintainability: eliminates bugs like PR #705

The easiest way to add libwrap to the app is to rebuild it as part of the GFXR build. While this means that the lib is being built twice, the extra time should not be noticable since libwrap is so small.

What could be more interesting though is that GFXR is built for debug so this extra copy is built for debug as well. Given that libwrap was originally built for debug (see PR #867), this shouldn't be an issue.