### PR TITLE
Enable variable shadowing warnings

### DIFF
--- a/dive_core/pm4_capture_data.h
+++ b/dive_core/pm4_capture_data.h
@@ -329,7 +329,6 @@ class Pm4CaptureData : public CaptureData
     RegisterInfo m_registers;
     MemoryManager m_memory;
     ProgressTracker* m_progress_tracker = nullptr;
-    std::string m_cur_capture_file;
     CaptureDataHeader m_data_header;
 };
 

--- a/src/dive/ui/utils/debug_utils.h
+++ b/src/dive/ui/utils/debug_utils.h
@@ -67,7 +67,7 @@ DebugScoped(FuncT&&) -> DebugScoped<FuncT>;
 template <typename FuncT>
 inline auto DebugScopedStopwatch(FuncT&& func)
 {
-    return DebugScoped([func = func, start = std::chrono::steady_clock::now()]() {
+    return DebugScoped([func, start = std::chrono::steady_clock::now()]() {
         auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(
                             std::chrono::steady_clock::now() - start)
                             .count();

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -43,6 +43,10 @@ if(MSVC)
     add_compile_options(
         /WX
         /W4
+        /w44456 # warn if local shadows previous local
+        /w44457 # warn if local shadows function parameter
+        /w44458 # warn if local shadows class member
+        /w44459 # warn if local shadows global variable
         /wd4201 # adreno.h uses non-standard nameless struct/union
         /wd4100 # emulate_pm4.h has unreferenced parameters
         /wd4127 # "conditional expression is constant" caused by Abseil

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -39,7 +39,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 20)
 
 if(MSVC)
-    add_compile_options(/WX /W4)
+    # TOOD: Remove /wd4100 after problems are fixed
+    add_compile_options(
+        /WX
+        /W4
+        /wd4201 # adreno.h uses non-standard nameless struct/union
+        /wd4100 # emulate_pm4.h has unreferenced parameters
+        /wd4127 # "conditional expression is constant" caused by Abseil
+        /wd4324 # "structure was padded" caused by Abseil flags
+    )
 else()
     add_compile_options(-Werror -Wall -Wshadow-all)
 endif()

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -38,6 +38,12 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 20)
 
+if(MSVC)
+    add_compile_options(/WX /W4)
+else()
+    add_compile_options(-Werror -Wall -Wshadow-all)
+endif()
+
 # Find the QtWidgets and QtSvg libraries
 find_package(Qt5 COMPONENTS Widgets Svg REQUIRED)
 
@@ -290,30 +296,6 @@ set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 )
-
-if(MSVC)
-    # 4099: missing PDB file for lib
-    # 4100: unreferenced formal parameter
-    # 4201: prevent nameless struct/union
-    # 4127: "conditional expression is constant" warnings
-    # 4324: structure was padded due to alignment specifier
-    # 4996: _CRT_SECURE_NO_WARNINGS
-    target_compile_options(
-        ${PROJECT_NAME}
-        PRIVATE /W4 /WX /wd4099 /wd4100 /wd4201 /wd4127 /wd4324 /wd4996
-    )
-else()
-    target_compile_options(
-        ${PROJECT_NAME}
-        PRIVATE
-            -Wall
-            -Wextra
-            -Werror
-            -Wno-unused-parameter
-            -Wno-missing-braces
-            -Wno-inconsistent-missing-override
-    )
-endif()
 
 if(MSVC)
     set_property(

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -39,7 +39,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 20)
 
 if(MSVC)
-    # TOOD: Remove /wd4100 after problems are fixed
+    # TOOD: b/509938195 - Remove /wd4100 after problems are fixed
     add_compile_options(
         /WX
         /W4
@@ -49,7 +49,12 @@ if(MSVC)
         /wd4324 # "structure was padded" caused by Abseil flags
     )
 else()
-    add_compile_options(-Werror -Wall -Wshadow-all)
+    add_compile_options(
+        -Werror
+        -Wall
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wshadow-all>
+        $<$<CXX_COMPILER_ID:GNU>:-Wshadow>
+    )
 endif()
 
 # Find the QtWidgets and QtSvg libraries

--- a/ui/capture_file_manager.cpp
+++ b/ui/capture_file_manager.cpp
@@ -179,7 +179,7 @@ void CaptureFileManager::StartLoadFile()
     auto request = m_pending_request.value();
     m_pending_request = std::nullopt;
     m_working = true;
-    QMetaObject::invokeMethod(m_worker, [this, request = request]() {
+    QMetaObject::invokeMethod(m_worker, [this, request]() {
         auto debug_timer = DebugScopedStopwatch([](double duration) {
             DIVE_DEBUG_LOG("Time used to load the capture is %f seconds.\n", duration);
         });

--- a/ui/most_expensive_events_view.cpp
+++ b/ui/most_expensive_events_view.cpp
@@ -41,7 +41,7 @@ const uint32_t kShaderStageColumn = 4;
 class EventWidgetItem : public QTreeWidgetItem
 {
  public:
-    EventWidgetItem(QTreeWidget* view) : QTreeWidgetItem(view) {}
+    EventWidgetItem(QTreeWidget* treeview) : QTreeWidgetItem(treeview) {}
     void SetStageEnabled(Dive::ShaderStage stage, bool enable)
     {
         m_stage_enabled[(uint32_t)stage] = enable;

--- a/ui/problems_view.cpp
+++ b/ui/problems_view.cpp
@@ -38,8 +38,8 @@ class ProblemWidgetItem : public QTreeWidgetItem
 {
  public:
     ProblemWidgetItem(Dive::CrossRef ref, std::string short_desc, std::string long_desc,
-                      QTreeWidget* view)
-        : QTreeWidgetItem(view), m_ref(ref), m_short_desc(short_desc), m_long_desc(long_desc)
+                      QTreeWidget* treeview)
+        : QTreeWidgetItem(treeview), m_ref(ref), m_short_desc(short_desc), m_long_desc(long_desc)
     {
     }
     Dive::CrossRef GetRef() const { return m_ref; }

--- a/ui/shader_view.cpp
+++ b/ui/shader_view.cpp
@@ -33,8 +33,8 @@ class ShaderWidgetItem : public QTreeWidgetItem
 {
  public:
     ShaderWidgetItem(Dive::ShaderStage shader_stage, Dive::CrossRef shader, uint32_t event_index,
-                     QTreeWidget* view)
-        : QTreeWidgetItem(view),
+                     QTreeWidget* treeview)
+        : QTreeWidgetItem(treeview),
           m_shader_stage(shader_stage),
           m_shader(shader),
           m_event_index(event_index)
@@ -44,9 +44,9 @@ class ShaderWidgetItem : public QTreeWidgetItem
     // TODO(tianc): make it so we don't need two different reference systems for crashdump and
     // profiler trace.
     ShaderWidgetItem(Dive::ShaderStage shader_stage, uint32_t shader_index, uint32_t event_index,
-                     QTreeWidget* view)
+                     QTreeWidget* treeview)
         : ShaderWidgetItem(shader_stage, Dive::CrossRef(Dive::CrossRefType::kNone, shader_index),
-                           event_index, view)
+                           event_index, treeview)
     {
     }
 

--- a/ui/shader_view.cpp
+++ b/ui/shader_view.cpp
@@ -172,18 +172,18 @@ void ShaderView::paintEvent(QPaintEvent* event)
             {
                 return;
             }
-            const Dive::EventInfo& event = metadata.m_event_info[event_id];
-            for (const auto& reference : event.m_shader_references)
+            const Dive::EventInfo& event_info = metadata.m_event_info[event_id];
+            for (const auto& reference : event_info.m_shader_references)
             {
                 auto shader_stage = (uint32_t)reference.m_stage;
                 // Do not add shaders that are not used by the event
-                if (event.m_type != Dive::Util::EventType::kDraw &&
-                    event.m_type != Dive::Util::EventType::kDispatch)
+                if (event_info.m_type != Dive::Util::EventType::kDraw &&
+                    event_info.m_type != Dive::Util::EventType::kDispatch)
                     continue;
-                if ((event.m_type == Dive::Util::EventType::kDraw) &&
+                if ((event_info.m_type == Dive::Util::EventType::kDraw) &&
                     (shader_stage == (uint32_t)Dive::ShaderStage::kShaderStageCs))
                     continue;
-                if ((event.m_type == Dive::Util::EventType::kDispatch) &&
+                if ((event_info.m_type == Dive::Util::EventType::kDispatch) &&
                     (shader_stage != (uint32_t)Dive::ShaderStage::kShaderStageCs))
                     continue;
 

--- a/ui/text_file_view.cpp
+++ b/ui/text_file_view.cpp
@@ -76,8 +76,8 @@ class TextFileWidgetItem : public QTreeWidgetItem
  public:
     typedef decltype(std::declval<Dive::Pm4CaptureData>().GetNumText()) IndexType;
 
-    TextFileWidgetItem(std::string name, IndexType index, QTreeWidget* view)
-        : QTreeWidgetItem(view), m_name(name), m_index(index)
+    TextFileWidgetItem(std::string name, IndexType index, QTreeWidget* treeview)
+        : QTreeWidgetItem(treeview), m_name(name), m_index(index)
     {
     }
     std::string GetName() const { return m_name; }


### PR DESCRIPTION
This would have caught the shadow issue introduced in #879 and fixed in PR #885. I've started in the ui folder but will apply this across Dive in a future PR.

Additionally, enable -Wall and -Werror for all targets in ui and subdirectories. This way, new targets also have the desired warning flags set.