### PR TITLE
Use common warnings in more places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ endif()
 
 message(CHECK_START "Generate build files for third_party/abseil-cpp")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
-add_subdirectory(third_party/abseil-cpp)
+add_subdirectory(third_party/abseil-cpp SYSTEM)
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 message(CHECK_PASS "done")
 

--- a/capture_service/CMakeLists.txt
+++ b/capture_service/CMakeLists.txt
@@ -20,12 +20,8 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-# Enable warnings as errors. Require exhaustive switches.
-if(MSVC)
-    add_compile_options(/WX /we4062)
-else()
-    add_compile_options(-Werror -Wswitch)
-endif()
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
 
 # AndroidTraceManager can be compiled on the host. This allows us to unit test it.
 # Group both cc files in the same target since the public header trace_mgr.h declares both.

--- a/capture_service/android_application.cc
+++ b/capture_service/android_application.cc
@@ -85,7 +85,7 @@ namespace Dive
 int GetIndentation(const std::string& line)
 {
     int indention = 0;
-    for (int i = 0; i < line.size(); i++)
+    for (int i = 0; i < static_cast<int>(line.size()); i++)
     {
         if (line[i] == ' ')
         {

--- a/capture_service/device_mgr.cc
+++ b/capture_service/device_mgr.cc
@@ -1128,15 +1128,13 @@ absl::Status DeviceManager::RunReplayApk(const GfxrReplaySettings& settings) con
 
     LOG(INFO) << "RunReplayApk(): Attempt to pin GPU clock frequency";
     bool trouble_pinning_clock = false;
-    auto ret = adb.Run("shell setprop compositor.high_priority 0");
-    if (!ret.ok())
+    if (auto ret = adb.Run("shell setprop compositor.high_priority 0"); !ret.ok())
     {
         LOG(WARNING) << "Could not disable the compositor preemption: " << ret.message();
         trouble_pinning_clock = true;
     }
     absl::Cleanup enable_compositor_preemption = [this, &adb] {
-        absl::Status ret = adb.Run("shell setprop compositor.high_priority 1");
-        if (!ret.ok())
+        if (absl::Status ret = adb.Run("shell setprop compositor.high_priority 1"); !ret.ok())
         {
             LOG(WARNING) << "Could not re-enable the compositor preemption: " << ret.message();
         }
@@ -1144,8 +1142,7 @@ absl::Status DeviceManager::RunReplayApk(const GfxrReplaySettings& settings) con
 
     if (!trouble_pinning_clock)
     {
-        ret = m_device->PinGpuClock(kPinGpuClockMHz);
-        if (!ret.ok())
+        if (auto ret = m_device->PinGpuClock(kPinGpuClockMHz); !ret.ok())
         {
             LOG(WARNING) << "Could not pin GPU clock: " << ret.message();
             trouble_pinning_clock = true;
@@ -1158,14 +1155,12 @@ absl::Status DeviceManager::RunReplayApk(const GfxrReplaySettings& settings) con
         }
 
         LOG(INFO) << "RunReplayApk(): Attempt to unpin GPU clock frequency";
-        auto ret = m_device->IsGpuClockPinned(kPinGpuClockMHz);
-        if (!ret.ok())
+        if (auto ret = m_device->IsGpuClockPinned(kPinGpuClockMHz); !ret.ok())
         {
             LOG(WARNING) << "GPU clock was not pinned: " << ret.message();
         }
 
-        ret = m_device->UnpinGpuClock();
-        if (!ret.ok())
+        if (auto ret = m_device->UnpinGpuClock(); !ret.ok())
         {
             LOG(WARNING) << "Could not unpin GPU clock: " << ret.message();
         }

--- a/capture_service/device_mgr.cc
+++ b/capture_service/device_mgr.cc
@@ -1133,7 +1133,7 @@ absl::Status DeviceManager::RunReplayApk(const GfxrReplaySettings& settings) con
         LOG(WARNING) << "Could not disable the compositor preemption: " << ret.message();
         trouble_pinning_clock = true;
     }
-    absl::Cleanup enable_compositor_preemption = [this, &adb] {
+    absl::Cleanup enable_compositor_preemption = [&adb] {
         if (absl::Status ret = adb.Run("shell setprop compositor.high_priority 1"); !ret.ok())
         {
             LOG(WARNING) << "Could not re-enable the compositor preemption: " << ret.message();

--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -1,0 +1,44 @@
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Enables common compiler warnings. This is directory-based (not target-based) so that new targets
+# also get the warnings enabled.
+function(enable_dive_compiler_warnings)
+    if(MSVC)
+        # TOOD: b/509938195 - Remove /wd4100 after problems are fixed
+        add_compile_options(
+            /WX
+            /W4
+            /w44456 # warn if local shadows previous local
+            /w44457 # warn if local shadows function parameter
+            /w44458 # warn if local shadows class member
+            /w44459 # warn if local shadows global variable
+            /wd4201 # adreno.h uses non-standard nameless struct/union
+            /wd4100 # emulate_pm4.h has unreferenced parameters
+            /wd4127 # "conditional expression is constant" caused by Abseil
+            /wd4324 # "structure was padded" caused by Abseil flags
+            /w44062 # require exhastive switches
+        )
+    else()
+        add_compile_options(
+            -Werror
+            -Wall
+            $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wshadow-all>
+            $<$<CXX_COMPILER_ID:GNU>:-Wshadow>
+            -Wswitch
+        )
+    endif()
+endfunction()

--- a/gfxr_ext/decode/CMakeLists.txt
+++ b/gfxr_ext/decode/CMakeLists.txt
@@ -37,11 +37,15 @@ endif()
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-if(MSVC)
-    add_compile_options(/WX /W4)
-else()
-    add_compile_options(-Werror -Wall)
-endif()
+include(../../cmake/compiler_warnings.cmake)
+enable_dive_compiler_warnings()
+
+add_library(gfxrecon_headers INTERFACE)
+target_include_directories(
+    gfxrecon_headers
+    SYSTEM
+    INTERFACE ../../third_party/gfxreconstruct/framework
+)
 
 add_library(dive_renderdoc)
 if(ANDROID)
@@ -51,10 +55,9 @@ else()
 endif()
 target_include_directories(
     dive_renderdoc
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/gfxreconstruct/framework
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../
 )
+target_link_libraries(dive_renderdoc PUBLIC gfxrecon_headers)
 
 # The Android Gradle script invokes its own CMake, starting from gfxrecon-replay's CMakeLists.txt.
 # This build system is isolated and does not see the gpu_time target defined in the root CMakeLists.txt.
@@ -81,11 +84,13 @@ add_library(
 )
 target_link_libraries(
     gfxr_decode_ext_lib
-    dive_renderdoc
-    gfxrecon_decode
-    gpu_time
-    absl::any_invocable
-    dive_renderdoc_files
+    PUBLIC
+        dive_renderdoc
+        gfxrecon_decode
+        gpu_time
+        absl::any_invocable
+        dive_renderdoc_files
+        gfxrecon_headers
 )
 # gfxr_util has a psapi dependency on Windows. Ideally, gfxr_util should declare this dependency in their CMakeLists.txt
 if(WIN32)
@@ -94,7 +99,6 @@ endif()
 target_include_directories(
     gfxr_decode_ext_lib
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/gfxreconstruct/framework
         ${CMAKE_CURRENT_SOURCE_DIR}/../../
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/dive # to be removed

--- a/gfxr_ext/decode/CMakeLists.txt
+++ b/gfxr_ext/decode/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(
 )
 # gfxr_util has a psapi dependency on Windows. Ideally, gfxr_util should declare this dependency in their CMakeLists.txt
 if(WIN32)
-    target_link_libraries(gfxr_decode_ext_lib psapi)
+    target_link_libraries(gfxr_decode_ext_lib PUBLIC psapi)
 endif()
 target_include_directories(
     gfxr_decode_ext_lib

--- a/gpu_time/CMakeLists.txt
+++ b/gpu_time/CMakeLists.txt
@@ -18,6 +18,9 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 # Since this might be included from GFXR build, ensure Vulkan::Headers is defined
 include(../cmake/vulkan.cmake)
 
+include(../cmake/compiler_warnings.cmake)
+enable_dive_compiler_warnings()
+
 add_library(
     gpu_time
     STATIC

--- a/gpu_time/gpu_time.cpp
+++ b/gpu_time/gpu_time.cpp
@@ -289,7 +289,7 @@ std::string GPUTime::GetStatsString() const
     const Stats stats = m_metrics.GetFrameTimeStats();
     std::stringstream ss;
     ss << "FrameMetrics:\n";
-    
+
     PopulateStatsString(ss, stats, 0);
 
     size_t renderpass_index = 0;

--- a/gpu_time/gpu_time.cpp
+++ b/gpu_time/gpu_time.cpp
@@ -279,16 +279,17 @@ size_t GPUTime::FrameMetrics::GetCmdRenderPassCount(size_t index) const
 
 std::string GPUTime::GetStatsString() const
 {
-    absl::MutexLock lock(&m_mutex);
-    const Stats stats = m_metrics.GetFrameTimeStats();
-    std::stringstream ss;
-    ss << "FrameMetrics:\n";
-
-    auto PopulateStatsString = [&](std::stringstream& ss, const Stats& stats, int nLevel) {
+    auto PopulateStatsString = [](std::stringstream& ss, const Stats& stats, int nLevel) {
         std::string indent(nLevel, '\t');
         ss << std::fixed << std::setprecision(2) << indent << "  Mean: " << stats.average << " ms\n"
            << indent << "  Median: " << stats.median << " ms\n";
     };
+
+    absl::MutexLock lock(&m_mutex);
+    const Stats stats = m_metrics.GetFrameTimeStats();
+    std::stringstream ss;
+    ss << "FrameMetrics:\n";
+    
     PopulateStatsString(ss, stats, 0);
 
     size_t renderpass_index = 0;

--- a/gpu_time/gpu_time_test.cpp
+++ b/gpu_time/gpu_time_test.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <vulkan/vulkan_core.h>
 
 namespace Dive
 {
@@ -419,7 +420,7 @@ TEST(GPUTimeTest, BeginCommandBufferForUnknownCmdDoesNotCrash)
     gpu_time.SetEnable(true);
     ASSERT_NO_FATAL_FAILURE(CreateGPUTime(gpu_time, kMockTimestampPeriod));
 
-    VkCommandBuffer unknown_cmd = reinterpret_cast<VkCommandBuffer>(0xdeadbeef);
+    MOCK_HANDLE(VkCommandBuffer, unknown_cmd, 0xdeadbeef);
 
     // This should return success (meaning it handled it gracefully) or at least not crash.
     // This is a legitimate case for secondary command buffers

--- a/src/dive/common/macros.h
+++ b/src/dive/common/macros.h
@@ -23,11 +23,11 @@ limitations under the License.
 #include "absl/status/statusor.h"
 
 // StatusOr Macros simplified from protobuf/stubs/status_macros.h
-#define RETURN_IF_ERROR(expr)               \
-    do                                      \
-    {                                       \
-        const absl::Status status = (expr); \
-        if (!status.ok()) return status;    \
+#define RETURN_IF_ERROR(expr)                                            \
+    do                                                                   \
+    {                                                                    \
+        const absl::Status return_if_error_status = (expr);              \
+        if (!return_if_error_status.ok()) return return_if_error_status; \
     } while (0)
 
 template <typename T>

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -38,28 +38,8 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 20)
 
-if(MSVC)
-    # TOOD: b/509938195 - Remove /wd4100 after problems are fixed
-    add_compile_options(
-        /WX
-        /W4
-        /w44456 # warn if local shadows previous local
-        /w44457 # warn if local shadows function parameter
-        /w44458 # warn if local shadows class member
-        /w44459 # warn if local shadows global variable
-        /wd4201 # adreno.h uses non-standard nameless struct/union
-        /wd4100 # emulate_pm4.h has unreferenced parameters
-        /wd4127 # "conditional expression is constant" caused by Abseil
-        /wd4324 # "structure was padded" caused by Abseil flags
-    )
-else()
-    add_compile_options(
-        -Werror
-        -Wall
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wshadow-all>
-        $<$<CXX_COMPILER_ID:GNU>:-Wshadow>
-    )
-endif()
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
 
 # Find the QtWidgets and QtSvg libraries
 find_package(Qt5 COMPONENTS Widgets Svg REQUIRED)


### PR DESCRIPTION
Create a CMake function to apply warnings more consistently. Apply to:

- capture_service
- gfxr_ext/decode
- gpu_time
- ui

Apply at using directory-based commands so that we can't forget to apply the config to a particular target.

This should catch more bugs.