### PR TITLE
Enable common warnings for all (but dive_core)

### DIFF
--- a/capture_service/device_mgr.h
+++ b/capture_service/device_mgr.h
@@ -69,8 +69,8 @@ enum class GfxrReplayOptions
 
 struct GfxrReplaySettings
 {
-    std::string remote_capture_path = "";
-    std::string local_download_dir = "";
+    std::string remote_capture_path;
+    std::string local_download_dir;
     GfxrReplayOptions run_type = GfxrReplayOptions::kNormal;
 
     // ----------------------------------------------------------------------
@@ -78,7 +78,7 @@ struct GfxrReplaySettings
 
     // Flags intended to be passed down to GFXR replay binary
     // Flags must be provided with a space (not '=') between flag and value
-    std::string replay_flags_str = "";
+    std::string replay_flags_str;
     // Wait for debugger to attach before continuing to replay.
     bool wait_for_debugger = false;
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_definitions(-DLITTLEENDIAN_CPU)
@@ -54,17 +57,6 @@ target_link_libraries(
 
 add_executable(${PROJECT_NAME} "main.cpp")
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_lib)
-
-if(MSVC)
-    # 4100: unreferenced formal parameter
-    # 4201: prevent nameless struct/union
-    target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX /wd4100 /wd4201)
-else()
-    target_compile_options(
-        ${PROJECT_NAME}
-        PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter -Wno-missing-braces
-    )
-endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     target_link_libraries(${PROJECT_NAME} PRIVATE dl)

--- a/cli/format_output.cpp
+++ b/cli/format_output.cpp
@@ -112,16 +112,16 @@ void PrintNodes(std::ostream& out, const Dive::CommandHierarchy* command_hierarc
                 const Dive::SharedNodeTopology& topology, uint64_t node_index, bool verbose)
 {
     VisitNodes(command_hierarchy_ptr, topology, node_index, 0,
-               [&out, command_hierarchy_ptr, &topology, verbose](uint64_t node_index,
+               [&out, command_hierarchy_ptr, &topology, verbose](uint64_t visit_node_index,
                                                                  uint32_t depth) -> bool {
                    for (uint32_t tab = 0; tab < depth; ++tab) out << "  ";
                    if (depth > 0) out << "| ";
 
-                   out << command_hierarchy_ptr->GetNodeDesc(node_index) << std::endl;
+                   out << command_hierarchy_ptr->GetNodeDesc(visit_node_index) << std::endl;
 
-                   if (verbose && 0 == topology.GetNumChildren(node_index))
+                   if (verbose && 0 == topology.GetNumChildren(visit_node_index))
                    {
-                       PrintSharedNodes(out, command_hierarchy_ptr, topology, node_index,
+                       PrintSharedNodes(out, command_hierarchy_ptr, topology, visit_node_index,
                                         depth + 1);
                    }
                    return true;

--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -39,6 +39,12 @@ function(enable_dive_compiler_warnings)
             $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wshadow-all>
             $<$<CXX_COMPILER_ID:GNU>:-Wshadow>
             -Wswitch
+            -Wextra
+            # TODO: b/509938195 - Rmeove -Wno-unused-parameter when problems are fixed
+            -Wno-unused-parameter
+            # -Wmissing-field-initializers fights with readability-redundant-member-init.
+            # Rely on clang-tidy to catch the important ommissions.
+            -Wno-missing-field-initializers
         )
     endif()
 endfunction()

--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -32,6 +32,7 @@ function(enable_dive_compiler_warnings)
             /wd4324 # "structure was padded" caused by Abseil flags
             /w44062 # require exhastive switches
         )
+        add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
     else()
         add_compile_options(
             -Werror

--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -41,7 +41,7 @@ function(enable_dive_compiler_warnings)
             $<$<CXX_COMPILER_ID:GNU>:-Wshadow>
             -Wswitch
             -Wextra
-            # TODO: b/509938195 - Rmeove -Wno-unused-parameter when problems are fixed
+            # TODO: b/509938195 - Remove -Wno-unused-parameter when problems are fixed
             -Wno-unused-parameter
             # -Wmissing-field-initializers fights with readability-redundant-member-init.
             # Rely on clang-tidy to catch the important ommissions.

--- a/gfxr_dump_resources/CMakeLists.txt
+++ b/gfxr_dump_resources/CMakeLists.txt
@@ -21,6 +21,9 @@ if(ANDROID)
 endif()
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 add_library(
     gfxr_dump_resources_lib
     STATIC

--- a/gfxr_dump_resources/gfxr_dump_resources.cpp
+++ b/gfxr_dump_resources/gfxr_dump_resources.cpp
@@ -74,7 +74,7 @@ bool SaveAsJsonFile(const std::vector<DumpEntry>& dumpables, const char* filenam
     out << "  },\n";
 
     out << "  \"BeginCommandBuffer\": [";
-    for (int i = 0; i < dumpables.size(); ++i)
+    for (size_t i = 0; i < dumpables.size(); ++i)
     {
         const DumpEntry& entry = dumpables[i];
         if (i != 0)
@@ -86,7 +86,7 @@ bool SaveAsJsonFile(const std::vector<DumpEntry>& dumpables, const char* filenam
     out << "],\n";
 
     out << "  \"RenderPass\": [";
-    for (int i = 0; i < dumpables.size(); ++i)
+    for (size_t i = 0; i < dumpables.size(); ++i)
     {
         const DumpEntry& entry = dumpables[i];
         if (i != 0)
@@ -94,7 +94,7 @@ bool SaveAsJsonFile(const std::vector<DumpEntry>& dumpables, const char* filenam
             out << ',';
         }
         out << '[';
-        for (int ii = 0; ii < entry.render_passes.size(); ++ii)
+        for (size_t ii = 0; ii < entry.render_passes.size(); ++ii)
         {
             const DumpRenderPass& render_pass = entry.render_passes[ii];
             if (ii != 0)
@@ -109,7 +109,7 @@ bool SaveAsJsonFile(const std::vector<DumpEntry>& dumpables, const char* filenam
     out << "],\n";
 
     out << "  \"Draw\": [";
-    for (int i = 0; i < dumpables.size(); ++i)
+    for (size_t i = 0; i < dumpables.size(); ++i)
     {
         const DumpEntry& entry = dumpables[i];
         if (i != 0)
@@ -117,7 +117,7 @@ bool SaveAsJsonFile(const std::vector<DumpEntry>& dumpables, const char* filenam
             out << ',';
         }
         out << '[';
-        for (int ii = 0; ii < entry.draws.size(); ++ii)
+        for (size_t ii = 0; ii < entry.draws.size(); ++ii)
         {
             uint64_t draw = entry.draws[ii];
             if (ii != 0)
@@ -131,7 +131,7 @@ bool SaveAsJsonFile(const std::vector<DumpEntry>& dumpables, const char* filenam
     out << "],\n";
 
     out << "  \"QueueSubmit\": [";
-    for (int i = 0; i < dumpables.size(); ++i)
+    for (size_t i = 0; i < dumpables.size(); ++i)
     {
         const DumpEntry& entry = dumpables[i];
         if (i != 0)

--- a/gfxr_dump_resources/state_machine.cpp
+++ b/gfxr_dump_resources/state_machine.cpp
@@ -26,8 +26,8 @@ namespace Dive::gfxr
 StateMachine::StateMachine(gfxrecon::format::HandleId command_buffer, AcceptingFunction accept,
                            RejectingFunction reject)
     : command_buffer_(command_buffer),
-      accept_(accept),
       reject_(reject),
+      accept_(accept),
       find_draw_(*this, find_render_pass_),
       find_render_pass_(*this, find_draw_),
       begin_state_(*this, find_render_pass_),

--- a/host_cli/CMakeLists.txt
+++ b/host_cli/CMakeLists.txt
@@ -31,6 +31,9 @@ endif()
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 # ---------------------
 # data_core_wrapper_lib
 add_library(data_core_wrapper_lib data_core_wrapper.h data_core_wrapper.cpp)

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -23,6 +23,9 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
 project(diveCaptureLayer)
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 set(CMAKE_CXX_STANDARD 20)
 set(target_name VkLayer_dive)
 
@@ -77,18 +80,6 @@ target_link_directories(
 if($<CONFIG:Release>)
     set_target_properties(${target_name} PROPERTIES LINK_FLAGS_RELEASE -s)
 endif()
-
-if(MSVC)
-    # 4100: unreferenced formal parameter
-    # 4201: prevent nameless struct/union
-    target_compile_options(${target_name} PRIVATE /W4 /WX /wd4100 /wd4201)
-else()
-    target_compile_options(
-        ${target_name}
-        PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter -Wno-missing-braces
-    )
-endif()
-
 set_target_properties(
     ${target_name}
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"

--- a/layer/openxr_layer.cc
+++ b/layer/openxr_layer.cc
@@ -244,14 +244,13 @@ XRAPI_ATTR XrResult XRAPI_CALL ApiDiveLayerXrDestroySession(XrSession session)
         g_xr_session_data.erase(DataKey(session));
     }
 
-    return XrResult::XR_ERROR_HANDLE_INVALID;
+    return result;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL ApiDiveLayerXrGetInstanceProcAddr(XrInstance instance,
                                                                  const char* name,
                                                                  PFN_xrVoidFunction* function)
 {
-    XrResult result = XR_ERROR_HANDLE_INVALID;
     std::string func_name = name;
     LOGD("xrGetInstanceProcAddr:  %s\n", func_name.c_str());
 

--- a/lrz_validator/CMakeLists.txt
+++ b/lrz_validator/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_executable(${PROJECT_NAME} "main.cpp")
@@ -41,17 +44,6 @@ target_include_directories(
     ${PROJECT_NAME}
     PRIVATE ${THIRDPARTY_DIRECTORY}/gfxreconstruct/framework
 )
-
-if(MSVC)
-    # 4100: unreferenced formal parameter
-    # 4201: prevent nameless struct/union
-    target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX /wd4100 /wd4201)
-else()
-    target_compile_options(
-        ${PROJECT_NAME}
-        PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter -Wno-missing-braces
-    )
-endif()
 
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 message(CHECK_PASS "done")

--- a/network/CMakeLists.txt
+++ b/network/CMakeLists.txt
@@ -19,6 +19,9 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
 project(network)
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 set(NETWORK_SRCS
     socket_connection.cc
     messages.cc

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -21,6 +21,9 @@ if(ANDROID)
 endif()
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 # For each new plugin, you can add an add_subdirectory call here.
 add_subdirectory(plugin_sample)
 

--- a/plugins/plugin_sample/plugin_sample.cpp
+++ b/plugins/plugin_sample/plugin_sample.cpp
@@ -28,11 +28,11 @@ namespace
 {
 #if defined(__APPLE__)
 constexpr std::string_view kPluginMessage =
-    "All plugin dynamic libraries need to be put into 'Contents/PlugIns/dive_plugins' "
-    "subdirectory.";
+    "All plugin .so(s) need to be put into 'Contents/PlugIns/dive_plugins' subdirectory.";
 #else
 constexpr std::string_view kPluginMessage =
-    "All plugin dynamic libraries need to be put into 'plugins' subdirectory.";
+    "All plugin .dll(s)/.so(s) need to be put into 'plugins' subdirectory longside the dive_ui "
+    "executable.";
 #endif
 }  // namespace
 
@@ -79,9 +79,7 @@ void PluginSample::OnPluginSampleActionTriggered()
 {
     QMessageBox::information(
         nullptr, QString::fromStdString("Plugin Info"),
-        QString::fromStdString(
-            "All plugin .dll(s)/.so(s) need to be put into 'plugins' subdirectory "
-            "alongside the dive_ui executable."));
+        QString::fromUtf8(kPluginMessage.data(), static_cast<int>(kPluginMessage.size())));
 }
 
 // This function must be exported from the shared library.

--- a/runtime_layer/CMakeLists.txt
+++ b/runtime_layer/CMakeLists.txt
@@ -23,6 +23,9 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
 project(diveRuntimeLayer)
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 set(CMAKE_CXX_STANDARD 20)
 set(target_name VkLayer_rt_dive)
 
@@ -60,17 +63,6 @@ target_link_libraries(${target_name} -lm -ldl -llog -landroid)
 
 if($<CONFIG:Release>)
     set_target_properties(${target_name} PROPERTIES LINK_FLAGS_RELEASE -s)
-endif()
-
-if(MSVC)
-    # 4100: unreferenced formal parameter
-    # 4201: prevent nameless struct/union
-    target_compile_options(${target_name} PRIVATE /W4 /WX /wd4100 /wd4201)
-else()
-    target_compile_options(
-        ${target_name}
-        PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter -Wno-missing-braces
-    )
 endif()
 
 set_target_properties(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+include(../cmake/compiler_warnings.cmake)
+enable_dive_compiler_warnings()
+
 add_library(dive_src_includes INTERFACE)
 target_include_directories(
     dive_src_includes

--- a/src/dive/common/status.cpp
+++ b/src/dive/common/status.cpp
@@ -35,14 +35,14 @@ std::string StackTraceString(int skip_count)
 {
     std::array<void*, kMaxDepth> frames{};
     // skip_count + 1 to ignore this function's own frame
-    int depth = absl::GetStackTrace(frames.data(), frames.size(), skip_count + 1);
+    int depth = absl::GetStackTrace(frames.data(), static_cast<int>(frames.size()), skip_count + 1);
 
     std::string stack;
     std::array<char, kMaxSymbolLength> buf{};
     for (int i = 0; i < depth; ++i)
     {
         const char* symbol = "(unknown)";
-        if (absl::Symbolize(frames[i], buf.data(), buf.size()))
+        if (absl::Symbolize(frames[i], buf.data(), static_cast<int>(buf.size())))
         {
             symbol = buf.data();
         }

--- a/src/dive/utils/version_info.cpp
+++ b/src/dive/utils/version_info.cpp
@@ -181,37 +181,38 @@ std::string GetLongVersionString()
 {
     std::string summary = GetHostToolsVersionInfo();
 
-    if (auto ret = ResolveDeviceResourcesLocalPath(GetDeviceResourcesVersionFileName()); ret.ok())
+    if (auto device_resources_version_path =
+            ResolveDeviceResourcesLocalPath(GetDeviceResourcesVersionFileName());
+        device_resources_version_path.ok())
     {
-        std::filesystem::path device_resources_version_path = *ret;
-        if (absl::StatusOr<std::string> ret =
-                ReadFileCapped(device_resources_version_path, kMaxCharsDeviceResourcesVersionFile);
-            ret.ok())
+        if (absl::StatusOr<std::string> file_contents =
+                ReadFileCapped(*device_resources_version_path, kMaxCharsDeviceResourcesVersionFile);
+            file_contents.ok())
         {
-            summary += "\n" + GetDeviceResourcesVersionInfo(*ret);
+            summary += "\n" + GetDeviceResourcesVersionInfo(*file_contents);
         }
         else
         {
-            LOG(ERROR) << ret.status().message();
+            LOG(ERROR) << file_contents.status().message();
         }
     }
     else
     {
-        LOG(ERROR) << ret.status().message();
+        LOG(ERROR) << device_resources_version_path.status().message();
     }
 
     std::filesystem::path profiling_sha_path =
         Dive::DeviceResourcesConstants::kProfilingPluginShaName;
 
-    if (auto ret = ResolveProfilingResourcesLocalPath(profiling_sha_path); ret.ok())
+    if (auto profiling_plugin_version_path = ResolveProfilingResourcesLocalPath(profiling_sha_path);
+        profiling_plugin_version_path.ok())
     {
-        std::filesystem::path profiling_plugin_version_path = *ret;
-        if (absl::StatusOr<std::string> ret =
-                ReadFileCapped(profiling_plugin_version_path, kLongSha);
-            ret.ok())
+        if (absl::StatusOr<std::string> file_contents =
+                ReadFileCapped(*profiling_plugin_version_path, kLongSha);
+            file_contents.ok())
         {
             std::string profiling_plugin_section =
-                absl::StrFormat("Profiling Plugin SHA: %s\n", *ret);
+                absl::StrFormat("Profiling Plugin SHA: %s\n", *file_contents);
             summary += "\n" + profiling_plugin_section;
         }
     }

--- a/trace_stats/CMakeLists.txt
+++ b/trace_stats/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
+enable_dive_compiler_warnings()
+
 add_library(dive_lib_trace_stats "trace_stats.cpp" "trace_stats.h")
 target_link_libraries(
     dive_lib_trace_stats
@@ -41,18 +44,6 @@ target_link_libraries(
 
 add_executable(${PROJECT_NAME} "main.cpp")
 target_link_libraries(${PROJECT_NAME} PRIVATE dive_lib_trace_stats)
-
-if(MSVC)
-    # 4100: unreferenced formal parameter
-    # 4201: prevent nameless struct/union
-    target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX /wd4100 /wd4201)
-    target_link_libraries(${PROJECT_NAME} PRIVATE psapi)
-else()
-    target_compile_options(
-        ${PROJECT_NAME}
-        PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter -Wno-missing-braces
-    )
-endif()
 
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 message(CHECK_PASS "done")


### PR DESCRIPTION
This is a follow-on to #894 that addresses the rest of the directories. I left dive_core since it's slightly trickier; this will be addressed in a future PR.

To harmonize the code base, I encorporated -Wextra into the common warnings as well.