### PR TITLE
Adds recursive force deletion of manifest folder path

### DIFF
--- a/capture_service/android_application.cc
+++ b/capture_service/android_application.cc
@@ -684,7 +684,7 @@ absl::Status OpenXRApplication::Pm4CaptureCleanup()
 {
     RETURN_IF_ERROR(m_dev.Adb().Run("remount"));
     RETURN_IF_ERROR(m_dev.Adb().Run(absl::StrFormat(
-        "shell rm -r %s", Dive::DeviceResourcesConstants::kDeployManifestFolderPath)));
+        "shell rm -rf %s", Dive::DeviceResourcesConstants::kDeployManifestFolderPath)));
     return absl::OkStatus();
 }
 


### PR DESCRIPTION
Changes the call to -rf prevents the command from failing if the folder has already been deleted or was never created.