### PR TITLE
Fix Runtime What-ifs

### DIFF
--- a/capture_service/android_application.cc
+++ b/capture_service/android_application.cc
@@ -475,6 +475,8 @@ absl::Status AndroidApplication::RuntimeWhatIfSetup()
     // New prop is prefixed with debug.
     RETURN_IF_ERROR(m_dev.Adb().Run("shell setprop debug.openxr.enable_frame_delimiter true"));
 
+    RETURN_IF_ERROR(m_dev.ForwardFirstAvailablePort());
+
     return absl::OkStatus();
 }
 
@@ -507,6 +509,7 @@ absl::Status AndroidApplication::RuntimeWhatIfCleanup()
 absl::Status AndroidApplication::CreateGfxrDirectory(const std::string directory)
 {
     RETURN_IF_ERROR(m_dev.Adb().Run(absl::StrFormat("shell mkdir -p %s", directory)));
+    RETURN_IF_ERROR(m_dev.Adb().Run(absl::StrFormat("shell chmod 777 %s", directory)));
 
     return absl::OkStatus();
 }

--- a/capture_service/constants.h
+++ b/capture_service/constants.h
@@ -35,11 +35,6 @@ inline constexpr char kGpuTimingFile[] = "gpu_time.csv";  // produced by GFXR re
 inline constexpr char kCaptureScreenshotFile[] =
     "capture_screenshot.png";  // produced during GFXR capture
 
-inline constexpr int kFirstPort =
-    49391;  // A port number within the dynamic port range (49152 to 65535)
-inline constexpr int kPortRange =
-    7;  // A small range of ports should be enough to find an available one
-
 // GPU clock
 inline constexpr uint32_t kPinGpuClockMHz = 545;
 inline constexpr char kDeviceGpuMinClockPath[] = "/sys/kernel/gpu/gpu_min_clock";

--- a/capture_service/device_mgr.cc
+++ b/capture_service/device_mgr.cc
@@ -514,6 +514,10 @@ absl::Status AndroidDevice::ForwardFirstAvailablePort()
 {
     for (int p = kFirstPort; p <= kFirstPort + kPortRange; p++)
     {
+        // Explicitly remove any existing forward for this port to avoid "port already in use"
+        // or stale rules issues after adb root.
+        Adb().Run(absl::StrFormat("forward --remove tcp:%d", p)).IgnoreError();
+
         auto res = Adb().RunAndGetResult(
             absl::StrFormat("forward tcp:%d localabstract:%s", p,
                             Dive::DeviceResourcesConstants::kUnixAbstractPath));
@@ -532,7 +536,6 @@ absl::Status AndroidDevice::SetupDevice()
 {
     if (m_runtime_what_if_enabled)
     {
-        RETURN_IF_ERROR(ForwardFirstAvailablePort());
         return absl::OkStatus();
     }
 
@@ -1398,6 +1401,11 @@ absl::Status AndroidDevice::TriggerScreenCapture(
         on_device_screenshot_dir / Dive::kCaptureScreenshotFile;
 
     std::string on_device_capture_screen_shot = full_capture_path.generic_string();
+    std::string on_device_capture_dir = full_capture_path.parent_path().generic_string();
+
+    // Ensure the directory exists before taking the screenshot.
+    RETURN_IF_ERROR(m_adb.Run(absl::StrFormat("shell mkdir -p %s", on_device_capture_dir)));
+    RETURN_IF_ERROR(m_adb.Run(absl::StrFormat("shell chmod 777 %s", on_device_capture_dir)));
 
     absl::Status ret =
         m_adb.Run(absl::StrFormat("shell screencap -p %s", on_device_capture_screen_shot));
@@ -1437,6 +1445,7 @@ absl::Status AndroidDevice::DeployDeviceResource(const std::string_view& file_na
     }
 
     RETURN_IF_ERROR(m_adb.Run(absl::StrFormat(R"(shell mkdir -p '%s')", target_dir)));
+    RETURN_IF_ERROR(m_adb.Run(absl::StrFormat(R"(shell chmod 777 '%s')", target_dir)));
 
     return m_adb.Run(
         absl::StrFormat(R"(push "%s" "%s")", host_full_lib_path.generic_string(), target_dir));

--- a/capture_service/device_mgr.cc
+++ b/capture_service/device_mgr.cc
@@ -514,24 +514,27 @@ absl::StatusOr<std::vector<std::string>> AndroidDevice::ListPackage(PackageListO
 absl::Status AndroidDevice::ForwardFirstAvailablePort()
 {
     // Explicitly remove any existing forward for the current port to avoid stale rules.
-    if (m_port != 0)
+    if (m_port.has_value())
     {
-        Adb().Run(absl::StrFormat("forward --remove tcp:%d", m_port)).IgnoreError();
-        m_port = 0;
+        Adb().Run(absl::StrFormat("forward --remove tcp:%d", *m_port)).IgnoreError();
+        m_port.reset();
     }
 
-    auto res = Adb().RunAndGetResult(absl::StrFormat(
+    auto new_port_str = Adb().RunAndGetResult(absl::StrFormat(
         "forward tcp:0 localabstract:%s", Dive::DeviceResourcesConstants::kUnixAbstractPath));
-    if (res.ok())
+    if (!new_port_str.ok())
     {
-        if (absl::SimpleAtoi(*res, &m_port))
-        {
-            return absl::OkStatus();
-        }
-        return absl::InternalError(
-            absl::StrFormat("Failed to parse port from adb output: %s", *res));
+        return new_port_str.status();
     }
-    return res.status();
+
+    int port_val = 0;
+    if (!absl::SimpleAtoi(*new_port_str, &port_val))
+    {
+        return absl::InternalError(
+            absl::StrFormat("Failed to parse port from adb output: %s", *new_port_str));
+    }
+    m_port = port_val;
+    return absl::OkStatus();
 }
 
 absl::Status AndroidDevice::SetupDevice()
@@ -592,11 +595,11 @@ absl::Status AndroidDevice::CleanupDevice()
         .IgnoreError();
     Adb().Run(absl::StrFormat("shell rm -rf -- %s", kReplayStateLoadedSignalFile)).IgnoreError();
     absl::StatusOr<std::string> output = Adb().RunAndGetResult(absl::StrFormat("forward --list"));
-    if (output.ok() && Port() != 0)
+    if (output.ok() && Port().has_value())
     {
-        if (output->find(std::to_string(Port())) != std::string::npos)
+        if (output->find(std::to_string(*Port())) != std::string::npos)
         {
-            Adb().Run(absl::StrFormat("forward --remove tcp:%d", Port())).IgnoreError();
+            Adb().Run(absl::StrFormat("forward --remove tcp:%d", *Port())).IgnoreError();
         }
     }
 

--- a/capture_service/device_mgr.cc
+++ b/capture_service/device_mgr.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
@@ -512,24 +513,25 @@ absl::StatusOr<std::vector<std::string>> AndroidDevice::ListPackage(PackageListO
 
 absl::Status AndroidDevice::ForwardFirstAvailablePort()
 {
-    for (int p = kFirstPort; p <= kFirstPort + kPortRange; p++)
+    // Explicitly remove any existing forward for the current port to avoid stale rules.
+    if (m_port != 0)
     {
-        // Explicitly remove any existing forward for this port to avoid "port already in use"
-        // or stale rules issues after adb root.
-        Adb().Run(absl::StrFormat("forward --remove tcp:%d", p)).IgnoreError();
+        Adb().Run(absl::StrFormat("forward --remove tcp:%d", m_port)).IgnoreError();
+        m_port = 0;
+    }
 
-        auto res = Adb().RunAndGetResult(
-            absl::StrFormat("forward tcp:%d localabstract:%s", p,
-                            Dive::DeviceResourcesConstants::kUnixAbstractPath));
-        if (res.ok())
+    auto res = Adb().RunAndGetResult(absl::StrFormat(
+        "forward tcp:0 localabstract:%s", Dive::DeviceResourcesConstants::kUnixAbstractPath));
+    if (res.ok())
+    {
+        if (absl::SimpleAtoi(*res, &m_port))
         {
-            m_port = p;
             return absl::OkStatus();
         }
+        return absl::InternalError(
+            absl::StrFormat("Failed to parse port from adb output: %s", *res));
     }
-    return absl::Status(absl::StatusCode::kUnknown,
-                        absl::StrFormat("Failed to forward available port between %d and %d",
-                                        kFirstPort, kFirstPort + kPortRange));
+    return res.status();
 }
 
 absl::Status AndroidDevice::SetupDevice()
@@ -590,7 +592,7 @@ absl::Status AndroidDevice::CleanupDevice()
         .IgnoreError();
     Adb().Run(absl::StrFormat("shell rm -rf -- %s", kReplayStateLoadedSignalFile)).IgnoreError();
     absl::StatusOr<std::string> output = Adb().RunAndGetResult(absl::StrFormat("forward --list"));
-    if (output.ok())
+    if (output.ok() && Port() != 0)
     {
         if (output->find(std::to_string(Port())) != std::string::npos)
         {

--- a/capture_service/device_mgr.h
+++ b/capture_service/device_mgr.h
@@ -163,7 +163,7 @@ class CAPTURE_SERVICE_EXPORT AndroidDevice
     absl::Status StopApp();
     const AdbSession& Adb() const { return m_adb; }
     AdbSession& Adb() { return m_adb; }
-    int Port() const { return m_port; }
+    std::optional<int> Port() const { return m_port; }
     bool IsAdrenoGpu() const { return m_dev_info.m_is_adreno_gpu; }
     std::string_view Serial() const { return m_serial; }
 
@@ -227,7 +227,7 @@ class CAPTURE_SERVICE_EXPORT AndroidDevice
     std::unique_ptr<AndroidApplication> m_app;
     std::optional<GfxrCaptureSettings> m_gfxr_capture_settings;
     bool m_runtime_what_if_enabled = false;
-    int m_port = 0;
+    std::optional<int> m_port;
 };
 
 class CAPTURE_SERVICE_EXPORT DeviceManager

--- a/capture_service/device_mgr.h
+++ b/capture_service/device_mgr.h
@@ -227,7 +227,7 @@ class CAPTURE_SERVICE_EXPORT AndroidDevice
     std::unique_ptr<AndroidApplication> m_app;
     std::optional<GfxrCaptureSettings> m_gfxr_capture_settings;
     bool m_runtime_what_if_enabled = false;
-    int m_port = kFirstPort;
+    int m_port = 0;
 };
 
 class CAPTURE_SERVICE_EXPORT DeviceManager

--- a/capture_service/dive_client_cli.cc
+++ b/capture_service/dive_client_cli.cc
@@ -382,9 +382,13 @@ absl::Status TriggerPm4Capture(const CommandContext& ctx)
 
     Network::TcpClient client;
     const std::string host = "127.0.0.1";
-    int port = device->Port();
+    std::optional<int> port = device->Port();
+    if (!port.has_value())
+    {
+        return Dive::FailedPreconditionError("Port not forwarded.");
+    }
 
-    absl::Status status = client.Connect(host, port);
+    absl::Status status = client.Connect(host, *port);
     if (!status.ok())
     {
         return Dive::StatusWithContext(status, "Connection failed");

--- a/ui/capture_worker.cpp
+++ b/ui/capture_worker.cpp
@@ -63,8 +63,15 @@ void CaptureWorker::run()
 
     Network::TcpClient client;
     const std::string host = "127.0.0.1";
-    int port = device->Port();
-    auto status = client.Connect(host, port);
+    std::optional<int> port = device->Port();
+    if (!port.has_value())
+    {
+        std::string err_msg = "Port not forwarded.";
+        qDebug() << err_msg.c_str();
+        emit ShowMessage(QString::fromStdString(err_msg));
+        return;
+    }
+    auto status = client.Connect(host, *port);
     if (!status.ok())
     {
         std::string err_msg(status.message());

--- a/ui/trace_dialog.cpp
+++ b/ui/trace_dialog.cpp
@@ -616,6 +616,7 @@ void TraceDialog::OnStartPackage()
                                  m_gfxr_capture_end_point_button_group->checkedId()),
                          })
                        : std::nullopt);
+    device->EnableRuntimeWhatIf(false);
     absl::Status ret = device->SetupDevice();
     if (!ret.ok())
     {

--- a/ui/what_if_setup_dialog.cpp
+++ b/ui/what_if_setup_dialog.cpp
@@ -691,14 +691,20 @@ Network::TcpClient* WhatIfSetupDialog::GetConnectedTcpClient()
     if (!m_tcp_client->IsConnected())
     {
         const std::string host = "127.0.0.1";
-        int port = device->Port();
+        std::optional<int> port = device->Port();
+        if (!port.has_value())
+        {
+            qDebug() << "GetConnectedTcpClient: Port not forwarded.";
+            ShowMessage(tr("Cannot connect to TCP server: Port not forwarded."));
+            return nullptr;
+        }
         qDebug() << "GetConnectedTcpClient: Client not connected. Attempting to connect to"
-                 << host.c_str() << ":" << port;
-        auto status = m_tcp_client->Connect(host, port);
+                 << host.c_str() << ":" << *port;
+        auto status = m_tcp_client->Connect(host, *port);
         if (!status.ok())
         {
             std::string err_msg = absl::StrFormat(
-                "Failed to connect to the application's TCP server at %s:%d.Error: %s", host, port,
+                "Failed to connect to the application's TCP server at %s:%d.Error: %s", host, *port,
                 status.message());
             qDebug() << "GetConnectedTcpClient:" << err_msg.c_str();
             ShowMessage(QString::fromStdString(err_msg));
@@ -706,7 +712,7 @@ Network::TcpClient* WhatIfSetupDialog::GetConnectedTcpClient()
             return nullptr;
         }
         qDebug() << "GetConnectedTcpClient: Successfully connected to" << host.c_str() << ":"
-                 << port;
+                 << *port;
     }
     else
     {


### PR DESCRIPTION
- Move `ForwardFirstAvailablePort()` from ` AndroidDevice::SetupDevice()` to the end of `AndroidApplication::RuntimeWhatIfSetup()`. (Before this fix, we call `adb root` after calling `ForwardFirstAvailablePort()` in ` AndroidDevice::SetupDevice()` which wipes out all existing adb forward rules associated with the device.)
- Disable runtime what-ifs before capturing