### PR TITLE
Disable DerivePointerAlignment in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,7 @@ AccessModifierOffset: -3
 
 # Fix clang-format-18's Google style:
 PointerAlignment: Left
+DerivePointerAlignment: false
 
 # Dive Specific:
 BraceWrapping:


### PR DESCRIPTION
- The default value is true, which means that if it detects that the file predominantly uses right-aligned pointers/references, it will silently override the `PointerAlignment: Left` setting.