### PR TITLE
Ensures dialogs are always in the foreground

### DIFF
--- a/ui/analyze_dialog.cpp
+++ b/ui/analyze_dialog.cpp
@@ -84,7 +84,9 @@ AnalyzeDialog::AnalyzeDialog(ApplicationController& controller,
     : DeviceDialog(parent), m_controller(controller), m_available_metrics(available_metrics)
 {
     qDebug() << "AnalyzeDialog created.";
-
+#if defined(__APPLE__)
+    setWindowFlags(windowFlags() | Qt::Tool);
+#endif
     m_overlay = new OverlayHelper(this);
 
     // Metrics List
@@ -439,7 +441,7 @@ void AnalyzeDialog::OnAnalyzeCaptureStarted(const QString& file_path)
 
     UpdateDeviceList();
     // Open the dialog for users to initiate analysis
-    show();
+    ShowAndRaise();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ui/analyze_dialog.cpp
+++ b/ui/analyze_dialog.cpp
@@ -84,9 +84,7 @@ AnalyzeDialog::AnalyzeDialog(ApplicationController& controller,
     : DeviceDialog(parent), m_controller(controller), m_available_metrics(available_metrics)
 {
     qDebug() << "AnalyzeDialog created.";
-#if defined(__APPLE__)
-    setWindowFlags(windowFlags() | Qt::Tool);
-#endif
+
     m_overlay = new OverlayHelper(this);
 
     // Metrics List

--- a/ui/device_dialog.cpp
+++ b/ui/device_dialog.cpp
@@ -89,12 +89,8 @@ void DeviceDialog::ShowAndRaise()
     {
         showNormal();
     }
-    else
+    else if (!isVisible())
     {
-        if (isVisible())
-        {
-            hide();
-        }
         show();
     }
     raise();

--- a/ui/device_dialog.cpp
+++ b/ui/device_dialog.cpp
@@ -26,6 +26,9 @@
 DeviceDialog::DeviceDialog(QWidget* parent) : QDialog(parent)
 {
     m_device_model = new QStandardItemModel(this);
+#if defined(__APPLE__)
+    setWindowFlags(windowFlags() | Qt::Tool);
+#endif
 }
 
 DeviceDialog::~DeviceDialog() {}
@@ -78,6 +81,24 @@ void DeviceDialog::UpdateDeviceList()
         index_to_select = 1;
     }
     m_device_box->setCurrentIndex(index_to_select);
+}
+
+void DeviceDialog::ShowAndRaise()
+{
+    if (isMinimized())
+    {
+        showNormal();
+    }
+    else
+    {
+        if (isVisible())
+        {
+            hide();
+        }
+        show();
+    }
+    raise();
+    activateWindow();
 }
 
 void DeviceDialog::OnDeviceSelectionChanged(const QString& s)

--- a/ui/device_dialog.h
+++ b/ui/device_dialog.h
@@ -33,6 +33,7 @@ class DeviceDialog : public QDialog
     virtual ~DeviceDialog();
     std::string GetCurrentDeviceSerial() const;
     void UpdateDeviceList();
+    void ShowAndRaise();
 
  protected:
     virtual void ShowMessage(const QString& message) = 0;

--- a/ui/main_window.cpp
+++ b/ui/main_window.cpp
@@ -1257,21 +1257,21 @@ void MainWindow::OnCaptureTrigger()
 void MainWindow::OnCapture(bool is_capture_delayed)
 {
     m_trace_dig->UpdateDeviceList();
-    m_trace_dig->show();
+    m_trace_dig->ShowAndRaise();
 }
 
 //--------------------------------------------------------------------------------------------------
 void MainWindow::OnWhatIfSetupTrigger()
 {
     m_what_if_setup_dig->UpdateDeviceList();
-    m_what_if_setup_dig->show();
+    m_what_if_setup_dig->ShowAndRaise();
 }
 
 //--------------------------------------------------------------------------------------------------
 void MainWindow::OnAddWhatIfModification()
 {
     m_what_if_configure_dig->SetTcpClient(m_what_if_setup_dig->GetConnectedTcpClient());
-    m_what_if_configure_dig->show();
+    m_what_if_configure_dig->ShowAndRaise();
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Ensures dialogs are always in the foreground and can be brought to the foreground on mac at all times.

**Manual Testing:**
Linux, MacOS, Windows

Minimize main window, load gfxr capture, open analyze dialog, maximize main window. Ensure dialog is still in the foreground.