### PR TITLE
Make some simple updates to the layer CMakeLists.txt and add TODOs

### DIFF
--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -14,20 +14,20 @@
 # limitations under the License.
 #
 
-message(CHECK_START "Generate build files for layer (diveCaptureLayer)")
+message(
+    CHECK_START
+    "Generate build files for layer (libVkLayer_dive.so, libXrApiLayer_dive.so)"
+)
 if(NOT ANDROID)
     message(CHECK_FAIL "not Android platform, skipping")
     return()
 endif()
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
-project(diveCaptureLayer)
-
 include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
 enable_dive_compiler_warnings()
 
 set(CMAKE_CXX_STANDARD 20)
-set(target_name VkLayer_dive)
 
 include_directories(
     ${CMAKE_SOURCE_DIR}
@@ -35,7 +35,7 @@ include_directories(
 )
 
 add_library(
-    ${target_name}
+    VkLayer_dive
     SHARED
     layer_common.h
     layer_common.cc
@@ -67,50 +67,48 @@ list(
     wrap
 )
 
-target_link_libraries(
-    ${target_name}
-    ${TARGET_LINK_LIBS}
-    PRIVATE Vulkan::Headers
-)
+target_link_libraries(VkLayer_dive ${TARGET_LINK_LIBS} PRIVATE Vulkan::Headers)
 target_link_directories(
-    ${target_name}
+    VkLayer_dive
     PRIVATE ${CMAKE_SOURCE_DIR}/capture_service
 )
 
+# TODO b/515779388 - Check if generator expression is misused
 if($<CONFIG:Release>)
-    set_target_properties(${target_name} PROPERTIES LINK_FLAGS_RELEASE -s)
+    set_target_properties(VkLayer_dive PROPERTIES LINK_FLAGS_RELEASE -s)
 endif()
 set_target_properties(
-    ${target_name}
+    VkLayer_dive
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"
 )
-install(TARGETS ${target_name} DESTINATION "${DIVE_DEST_DEVICE}")
+install(TARGETS VkLayer_dive DESTINATION "${DIVE_DEST_DEVICE}")
 
-set(target_name XrApiLayer_dive)
 set(XR_LAYER_SRC_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/openxr_layer.cc"
     "${CMAKE_SOURCE_DIR}/third_party/OpenXR-SDK/src/xr_generated_dispatch_table.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/layer_common.cc"
 )
 
-add_library(${target_name} SHARED ${XR_LAYER_SRC_FILES})
+add_library(XrApiLayer_dive SHARED ${XR_LAYER_SRC_FILES})
 set_target_properties(
-    ${target_name}
+    XrApiLayer_dive
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"
 )
 target_include_directories(
-    ${target_name}
+    XrApiLayer_dive
     PUBLIC
         ${CMAKE_SOURCE_DIR}/third_party/OpenXR-SDK/include
         ${CMAKE_SOURCE_DIR}/third_party/OpenXR-SDK/src
         ${CMAKE_SOURCE_DIR}/third_party/OpenXR-SDK/src/common
 )
-if($<CONFIG:Release>)
-    set_target_properties(${target_name} PROPERTIES LINK_FLAGS_RELEASE -s)
-endif()
-target_link_libraries(${target_name} ${TARGET_LINK_LIBS})
 
-install(TARGETS ${target_name} DESTINATION "${DIVE_DEST_DEVICE}")
+# TODO b/515779388 - Check if generator expression is misused
+if($<CONFIG:Release>)
+    set_target_properties(XrApiLayer_dive PROPERTIES LINK_FLAGS_RELEASE -s)
+endif()
+target_link_libraries(XrApiLayer_dive ${TARGET_LINK_LIBS})
+
+install(TARGETS XrApiLayer_dive DESTINATION "${DIVE_DEST_DEVICE}")
 
 configure_file(manifest/XrApiLayer_dive.json.in manifest/XrApiLayer_dive.json)
 install(

--- a/runtime_layer/CMakeLists.txt
+++ b/runtime_layer/CMakeLists.txt
@@ -14,20 +14,20 @@
 # limitations under the License.
 #
 
-message(CHECK_START "Generate build files for runtime_layer (diveRuntimeLayer)")
+message(
+    CHECK_START
+    "Generate build files for runtime_layer (libVkLayer_rt_dive.so)"
+)
 if(NOT (ANDROID OR CMAKE_HOST_WIN32))
     message(CHECK_FAIL "not Android or Windows platform, skipping")
     return()
 endif()
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
-project(diveRuntimeLayer)
-
 include("${dive_SOURCE_DIR}/cmake/compiler_warnings.cmake")
 enable_dive_compiler_warnings()
 
 set(CMAKE_CXX_STANDARD 20)
-set(target_name VkLayer_rt_dive)
 
 set(HDR_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/vk_rt_dispatch.h"
@@ -45,10 +45,10 @@ set(SRC_FILES
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/gpu_time)
 
-add_library(${target_name} SHARED ${HDR_FILES} ${SRC_FILES})
+add_library(VkLayer_rt_dive SHARED ${HDR_FILES} ${SRC_FILES})
 
 target_link_libraries(
-    ${target_name}
+    VkLayer_rt_dive
     dive_legacy_includes
     gpu_time
     Vulkan::Headers
@@ -59,21 +59,22 @@ target_link_libraries(
 )
 
 add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-target_link_libraries(${target_name} -lm -ldl -llog -landroid)
+target_link_libraries(VkLayer_rt_dive -lm -ldl -llog -landroid)
 
+# TODO b/515779388 - Check if generator expression is misused
 if($<CONFIG:Release>)
-    set_target_properties(${target_name} PROPERTIES LINK_FLAGS_RELEASE -s)
+    set_target_properties(VkLayer_rt_dive PROPERTIES LINK_FLAGS_RELEASE -s)
 endif()
 
 set_target_properties(
-    ${target_name}
+    VkLayer_rt_dive
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/"
 )
 
 if(ANDROID)
-    install(TARGETS ${target_name} DESTINATION "${DIVE_DEST_DEVICE}")
+    install(TARGETS VkLayer_rt_dive DESTINATION "${DIVE_DEST_DEVICE}")
 else()
-    install(TARGETS ${target_name} DESTINATION "${DIVE_DEST_HOST}")
+    install(TARGETS VkLayer_rt_dive DESTINATION "${DIVE_DEST_HOST}")
 endif()
 
 list(POP_BACK CMAKE_MESSAGE_INDENT)

--- a/runtime_layer/CMakeLists.txt
+++ b/runtime_layer/CMakeLists.txt
@@ -18,8 +18,8 @@ message(
     CHECK_START
     "Generate build files for runtime_layer (libVkLayer_rt_dive.so)"
 )
-if(NOT (ANDROID OR CMAKE_HOST_WIN32))
-    message(CHECK_FAIL "not Android or Windows platform, skipping")
+if(NOT ANDROID)
+    message(CHECK_FAIL "not Android platform, skipping")
     return()
 endif()
 list(APPEND CMAKE_MESSAGE_INDENT "  ")


### PR DESCRIPTION
This shouldn't affect the build process significantly, just intended to align more with cmake best practices

Changes:
* Remove `project()` in subfolders
* Remove use of `${target_name}`
* Add TODOs for further modernization
* No longer allow `runtime_layer/` to be built targeting Windows platform