### PR TITLE
Adding CaptureManager and AndroidCaptureManager

### DIFF
--- a/capture_service/CMakeLists.txt
+++ b/capture_service/CMakeLists.txt
@@ -40,6 +40,27 @@ target_link_libraries(
         dive_device_resources_constants
 )
 
+add_library(
+    capture_mgr
+    android_capture_mgr.cc
+    android_capture_mgr.h
+    capture_mgr.cc
+    capture_mgr.h
+)
+target_link_libraries(
+    capture_mgr
+    PUBLIC
+        dive_legacy_includes
+        absl::core_headers
+        absl::synchronization
+        absl::time
+        absl::str_format
+        absl::strings
+        absl::log
+        dive_device_resources_constants
+)
+target_include_directories(capture_mgr PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
 if(ANDROID)
     add_library(service service.cc)
 else()
@@ -201,6 +222,22 @@ else()
         gtest_main
     )
     gtest_discover_tests(android_trace_mgr_test)
+
+    add_executable(android_capture_mgr_test android_capture_mgr_test.cc)
+    target_link_libraries(
+        android_capture_mgr_test
+        absl::status_matchers
+        absl::strings
+        capture_mgr
+        gtest
+        gtest_main
+        gmock
+    )
+    target_include_directories(
+        android_capture_mgr_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..
+    )
+    gtest_discover_tests(android_capture_mgr_test)
 endif()
 
 list(POP_BACK CMAKE_MESSAGE_INDENT)

--- a/capture_service/android_capture_mgr.cc
+++ b/capture_service/android_capture_mgr.cc
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "android_capture_mgr.h"
+
+#include <string>
+#include <string_view>
+
+#include "absl/base/log_severity.h"
+#include "absl/log/log.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "dive/utils/device_resources_constants.h"
+
+extern "C"
+{
+    void SetCaptureState(int state);
+    void SetCaptureName(const char* name, const char* frame_num);
+}
+
+namespace Dive
+{
+
+namespace
+{
+static constexpr std::string_view kFrameConfigTracePrefix = "trace-frame";
+static constexpr std::string_view kDurationConfigTracePrefix = "trace";
+}  // namespace
+
+absl::Status AndroidCaptureManager::FromTriggeredToTracing(const TraceSettings& trace_settings)
+{
+    m_curr_trace_result = {};
+    std::string prefix = "";
+    size_t suffix_number = 0;
+
+    switch (trace_settings.mode)
+    {
+        case TraceMode::Duration:
+        {
+            prefix = kDurationConfigTracePrefix;
+            suffix_number = trace_settings.session_frame_index;
+            break;
+        }
+        case TraceMode::Frame:
+        {
+            prefix = kFrameConfigTracePrefix;
+            suffix_number = trace_settings.trace_started_frame;
+            break;
+        }
+        default:
+        {
+            return absl::FailedPreconditionError(
+                absl::StrFormat("Unrecognized TraceMode: %d", trace_settings.mode));
+        }
+    }
+
+    // This is an Android path so the path separator must be "/" regardless of host platform
+    std::string partial_path =
+        absl::StrFormat("%s/%s", DeviceResourcesConstants::kDeviceDownloadPath, prefix);
+    std::string trace_num_str = absl::StrFormat("%04u", suffix_number);
+    std::string full_path = absl::StrFormat("%s-%s.rd", partial_path, trace_num_str);
+
+    m_curr_trace_result.file_path = full_path;
+    LOG(INFO) << "Set capture file path in AndroidCaptureManager: "
+              << m_curr_trace_result.file_path;
+
+    // Set up libwrap
+    // We can't give libwrap `full_path` so we expect it to combine these parts as above.
+    SetCaptureName(partial_path.c_str(), trace_num_str.c_str());
+    LOG(INFO) << "Passed to libwrap: " << partial_path << ", " << trace_num_str;
+
+    // Tell libwrap to start capture
+    SetCaptureState(1);
+
+    return absl::OkStatus();
+}
+
+absl::Status AndroidCaptureManager::FromTracingToFinished()
+{
+    // Tell libwrap to end capture
+    SetCaptureState(0);
+    return absl::OkStatus();
+}
+
+absl::StatusOr<CaptureManager::TraceResult> AndroidCaptureManager::FromFinishedToIdle()
+{
+    if (m_curr_trace_result.file_path.empty())
+    {
+        return absl::NotFoundError("Current finished trace is empty");
+    }
+    return m_curr_trace_result;
+}
+
+AndroidCaptureManager& GetDefaultAndroidCaptureManager()
+{
+    static AndroidCaptureManager android_trace_mgr;
+    return android_trace_mgr;
+}
+
+}  // namespace Dive

--- a/capture_service/android_capture_mgr.h
+++ b/capture_service/android_capture_mgr.h
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+#include "capture_service/capture_mgr.h"
+
+namespace Dive
+{
+
+class AndroidCaptureManager : public CaptureManager
+{
+ private:
+    // Sets up CaptureManager and libwrap with the appropriate trace name and/or path in prepration
+    // for triggering the PM4 capture
+    // Name syntax examples:
+    //   - trace-frame-0003.rd : Frame-based trace, initiated at application frame 3
+    //   - trace-0005.rd: Duration based trace, 5th taken in this Dive session
+    virtual absl::Status FromTriggeredToTracing(const TraceSettings& trace_settings) override;
+    virtual absl::Status FromTracingToFinished() override;
+    virtual absl::StatusOr<CaptureManager::TraceResult> FromFinishedToIdle() override;
+
+    CaptureManager::TraceResult m_curr_trace_result = {};
+};
+
+AndroidCaptureManager& GetDefaultAndroidCaptureManager();
+
+}  // namespace Dive

--- a/capture_service/android_capture_mgr_test.cc
+++ b/capture_service/android_capture_mgr_test.cc
@@ -1,0 +1,290 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "android_capture_mgr.h"
+
+#include "absl/status/status_matchers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/time/time.h"
+#include "capture_service/capture_mgr.h"
+#include "dive/utils/device_resources_constants.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// AndroidCaptureManager uses these functions to talk with libwrap. They must be defined at link
+// time. In the future, we might be able to use them to assert state.
+extern "C"
+{
+    void SetCaptureState(int state) {}
+    void SetCaptureName(const char* name, const char* frame_num) {}
+}
+
+namespace Dive
+{
+namespace
+{
+
+using ::absl_testing::IsOk;
+using ::absl_testing::IsOkAndHolds;
+using ::absl_testing::StatusIs;
+
+TEST(AndroidCaptureManagerTest, TraceByFrameSuccessful)
+{
+    AndroidCaptureManager android_trace_manager;
+    AndroidCaptureManager::TraceByFrameConfig frame_config;
+
+    frame_config.total_frames = 1;
+    android_trace_manager.SetFrameConfig(frame_config);
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 0);
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 1);
+    // This request to trace will be deferred until the next frame boundary, i.e. frame 2.
+    EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Triggered));
+
+    // We should start tracing on this frame boundary
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 2);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+    // We should stop tracing on this frame boundary
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 3);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 4);
+    // State stalls at Finished until the user fetches the result with GetFinishedTracePath()
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+    // Can detect that a frame-based trace was chosen based on the trace file path prefix.
+    std::string expected_trace_result =
+        absl::StrCat(Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-frame-0002.rd");
+    EXPECT_THAT(android_trace_manager.GetFinishedTracePath(), IsOkAndHolds(expected_trace_result));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 5);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+}
+
+TEST(AndroidCaptureManagerTest, TraceByDurationSuccessful)
+{
+    AndroidCaptureManager android_trace_manager;
+    AndroidCaptureManager::TraceByDurationConfig duration_config;
+
+    duration_config.trace_duration = absl::Milliseconds(1);
+    android_trace_manager.SetDurationConfig(duration_config);
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+
+    // Unlike in Frame mode, TriggerTrace() for Duration mode will go through Triggered and end in
+    // Tracing state.
+    EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+    bool finished = false;
+    while (!finished)
+    {
+        absl::StatusOr<bool> res = android_trace_manager.IsTraceFinished();
+        EXPECT_THAT(res, IsOk());
+        finished = *res;
+    }
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+    // Can detect trace by duration based on the trace file path prefix.
+    std::string expected_trace_result =
+        absl::StrCat(Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-0000.rd");
+    EXPECT_THAT(android_trace_manager.GetFinishedTracePath(), IsOkAndHolds(expected_trace_result));
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+}
+
+TEST(AndroidCaptureManagerTest, TwoFrameTracesInSameSessionSuccessful)
+{
+    AndroidCaptureManager android_trace_manager;
+    AndroidCaptureManager::TraceByFrameConfig frame_config;
+
+    frame_config.total_frames = 1;
+    android_trace_manager.SetFrameConfig(frame_config);
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 0);
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 1);
+    // Trace 1: This request to trace will be deferred until the next frame boundary, i.e. frame 2.
+    EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Triggered));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 2);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 3);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+    std::string expected_trace_result =
+        absl::StrCat(Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-frame-0002.rd");
+    EXPECT_THAT(android_trace_manager.GetFinishedTracePath(), IsOkAndHolds(expected_trace_result));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 4);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+    // Trace 2: This request to trace will be deferred until the next frame boundary, i.e. frame 5.
+    EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Triggered));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 5);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 6);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+    expected_trace_result =
+        absl::StrCat(Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-frame-0005.rd");
+    EXPECT_THAT(android_trace_manager.GetFinishedTracePath(), IsOkAndHolds(expected_trace_result));
+
+    android_trace_manager.OnNewFrame();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 7);
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+}
+
+TEST(AndroidCaptureManagerTest, TwoDurationTracesInSameSessionSuccessful)
+{
+    AndroidCaptureManager android_trace_manager;
+    AndroidCaptureManager::TraceByDurationConfig duration_config;
+
+    duration_config.trace_duration = absl::Milliseconds(1);
+    android_trace_manager.SetDurationConfig(duration_config);
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+
+    // Trace 1
+    EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+    bool finished = false;
+    while (!finished)
+    {
+        absl::StatusOr<bool> res = android_trace_manager.IsTraceFinished();
+        EXPECT_THAT(res, IsOk());
+        finished = *res;
+    }
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+    std::string expected_trace_result =
+        absl::StrCat(Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-0000.rd");
+    EXPECT_THAT(android_trace_manager.GetFinishedTracePath(), IsOkAndHolds(expected_trace_result));
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+
+    // Trace 2
+    EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+    finished = false;
+    while (!finished)
+    {
+        absl::StatusOr<bool> res = android_trace_manager.IsTraceFinished();
+        EXPECT_THAT(res, IsOk());
+        finished = *res;
+    }
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+    expected_trace_result =
+        absl::StrCat(Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-0001.rd");
+    EXPECT_THAT(android_trace_manager.GetFinishedTracePath(), IsOkAndHolds(expected_trace_result));
+
+    EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+}
+
+TEST(AndroidCaptureManagerTest, FrameAndDurationTraceInSeparateSessionsSuccessful)
+{
+    AndroidCaptureManager android_trace_manager;
+    {
+        AndroidCaptureManager::TraceByFrameConfig frame_config;
+        frame_config.total_frames = 1;
+        android_trace_manager.SetFrameConfig(frame_config);
+
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+        EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 0);
+
+        android_trace_manager.OnNewFrame();
+        EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 1);
+        // Trace 1: Frame Trace
+        // This request to trace will be deferred until the next frame boundary, i.e. frame 2.
+        EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Triggered));
+
+        android_trace_manager.OnNewFrame();
+        EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 2);
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+        android_trace_manager.OnNewFrame();
+        EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 3);
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+        std::string expected_trace_result = absl::StrCat(
+            Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-frame-0002.rd");
+        EXPECT_THAT(android_trace_manager.GetFinishedTracePath(),
+                    IsOkAndHolds(expected_trace_result));
+    }
+
+    android_trace_manager.ResetAppSession();
+    EXPECT_EQ(android_trace_manager.GetApplicationFrames(), 0);
+
+    {
+        AndroidCaptureManager::TraceByDurationConfig duration_config;
+        duration_config.trace_duration = absl::Milliseconds(1);
+        android_trace_manager.SetDurationConfig(duration_config);
+
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+
+        // Trace 1
+        EXPECT_THAT(android_trace_manager.TriggerTrace(), IsOk());
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Tracing));
+
+        bool finished = false;
+        while (!finished)
+        {
+            absl::StatusOr<bool> res = android_trace_manager.IsTraceFinished();
+            EXPECT_THAT(res, IsOk());
+            finished = *res;
+        }
+
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Finished));
+
+        std::string expected_trace_result =
+            absl::StrCat(Dive::DeviceResourcesConstants::kDeviceDownloadPath, "/trace-0000.rd");
+        EXPECT_THAT(android_trace_manager.GetFinishedTracePath(),
+                    IsOkAndHolds(expected_trace_result));
+
+        EXPECT_TRUE(android_trace_manager.IsState(AndroidCaptureManager::TraceState::Idle));
+    }
+}
+
+// TODO: two app sessions, frame followed by duration trace
+
+}  // namespace
+}  // namespace Dive

--- a/capture_service/capture_mgr.cc
+++ b/capture_service/capture_mgr.cc
@@ -1,0 +1,344 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "capture_mgr.h"
+
+#include "absl/base/log_severity.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+
+namespace Dive
+{
+
+std::string CaptureManager::TraceState2Str(CaptureManager::TraceState state)
+{
+    switch (state)
+    {
+        case TraceState::Unknown:
+            return "Unknown";
+        case TraceState::Idle:
+            return "Idle";
+        case TraceState::Triggered:
+            return "Triggered";
+        case TraceState::Tracing:
+            return "Tracing";
+        case TraceState::Finished:
+            return "Finished";
+        default:
+            return "INVALID";
+    }
+}
+
+std::string CaptureManager::TraceMode2Str(CaptureManager::TraceMode mode)
+{
+    switch (mode)
+    {
+        case TraceMode::Unknown:
+            return "Unknown";
+        case TraceMode::Duration:
+            return "Duration";
+        case TraceMode::Frame:
+            return "Frame";
+        default:
+            return "INVALID";
+    }
+}
+
+void CaptureManager::OnNewFrame() ABSL_LOCKS_EXCLUDED(m_state_lock)
+{
+    absl::MutexLock lock(&m_state_lock);
+    m_application_frames++;
+
+    m_mode = TraceMode::Frame;
+
+    if (absl::Status res = ProcessState(); !res.ok())
+    {
+        LOG(ERROR) << res.message();
+    }
+}
+
+absl::Status CaptureManager::TriggerTrace() ABSL_LOCKS_EXCLUDED(m_state_lock)
+{
+    absl::MutexLock lock(&m_state_lock);
+    if (m_state != TraceState::Idle)
+    {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Can only trigger trace when TraceManger is Idle, not TraceState: %s. Try ResetTrace()",
+            TraceState2Str(m_state)));
+    }
+
+    m_state = TraceState::Triggered;
+
+    LOG(INFO) << "Successfully triggered a trace";
+
+    if (m_mode == TraceMode::Frame)
+    {
+        return absl::OkStatus();
+    }
+
+    if (absl::Status res = ProcessState(); !res.ok())
+    {
+        return res;
+    }
+    return absl::OkStatus();
+}
+
+absl::StatusOr<bool> CaptureManager::IsTraceFinished() ABSL_LOCKS_EXCLUDED(m_state_lock)
+{
+    absl::MutexLock lock(&m_state_lock);
+
+    if ((m_state == TraceState::Idle) || (m_state == TraceState::Unknown))
+    {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Invalid TraceState, waiting won't make it more Finished, current TraceState: %s",
+            TraceState2Str(m_state)));
+    }
+
+    if (!m_curr_trace_settings.has_value())
+    {
+        if ((m_state == TraceState::Tracing) || (m_state == TraceState::Finished))
+        {
+            return absl::FailedPreconditionError(
+                "m_curr_trace_settings cannot be empty when the state is Tracing/Finished");
+        }
+        if (m_state == TraceState::Triggered)
+        {
+            // Edge case for a Frame mode trace, where IsTraceFinished() was called between
+            // TriggerTrace() and the next OnNewFrame()
+            return false;
+        }
+    }
+
+    switch (m_curr_trace_settings->mode)
+    {
+        case TraceMode::Frame:
+        {
+            return m_state == TraceState::Finished;
+        }
+        case TraceMode::Duration:
+        {
+            if (m_state == TraceState::Finished)
+            {
+                return true;
+            }
+            if (absl::Status res = ProcessState(); !res.ok())
+            {
+                m_state = TraceState::Unknown;
+                return res;
+            }
+            return false;
+        }
+        default:
+        {
+            return absl::FailedPreconditionError(absl::StrFormat(
+                "Unrecognized current TraceMode: %s", TraceMode2Str(m_curr_trace_settings->mode)));
+        }
+    }
+}
+
+absl::StatusOr<std::string> CaptureManager::GetFinishedTracePath() ABSL_LOCKS_EXCLUDED(m_state_lock)
+{
+    absl::MutexLock lock(&m_state_lock);
+
+    if (m_state != TraceState::Finished)
+    {
+        return absl::FailedPreconditionError(
+            absl::StrFormat("Can only GetFinishedTracePath() when TraceManger is Finished, not "
+                            "TraceState: %s. Try WaitTraceFinished() or ResetTrace()",
+                            TraceState2Str(m_state)));
+    }
+
+    absl::StatusOr<TraceResult> trace_result = FromFinishedToIdle();
+    if (!trace_result.ok())
+    {
+        m_state = TraceState::Unknown;
+        return trace_result.status();
+    }
+
+    LOG(INFO) << "On-device trace path: " << trace_result->file_path;
+
+    m_traces_this_session++;
+    m_curr_trace_settings = std::nullopt;
+    m_state = TraceState::Idle;
+
+    return trace_result->file_path;
+}
+
+void CaptureManager::ResetTrace() ABSL_LOCKS_EXCLUDED(m_state_lock)
+{
+    absl::MutexLock lock(&m_state_lock);
+    LOG(INFO) << "CaptureManager::ResetTrace()";
+    m_curr_trace_settings = std::nullopt;
+    m_state = TraceState::Idle;
+
+    // We assume the same application is still running, so no reset for application-level members
+}
+
+void CaptureManager::ResetAppSession() ABSL_LOCKS_EXCLUDED(m_state_lock)
+{
+    absl::MutexLock lock(&m_state_lock);
+    LOG(INFO) << "CaptureManager::ResetAppSession()";
+    m_curr_trace_settings = std::nullopt;  // Otherwise "started" parameters here can be invalid
+    m_state = TraceState::Idle;
+
+    // Reset application
+    m_traces_this_session = 0;
+    m_application_frames = 0;
+    m_mode = TraceMode::Duration;
+}
+
+void CaptureManager::SetFrameConfig(const CaptureManager::TraceByFrameConfig config)
+{
+    m_frame_config = config;
+}
+
+void CaptureManager::SetDurationConfig(const CaptureManager::TraceByDurationConfig config)
+{
+    m_duration_config = config;
+}
+
+bool CaptureManager::IsState(TraceState state) ABSL_LOCKS_EXCLUDED(m_state_lock)
+{
+    absl::MutexLock lock(&m_state_lock);
+    if (state != m_state)
+    {
+        LOG(WARNING) << "Current state (" << TraceState2Str(m_state) << ") is not the expected ("
+                     << TraceState2Str(state) << ")";
+        return false;
+    }
+    return true;
+}
+
+absl::StatusOr<bool> CaptureManager::TraceShouldEnd() ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock)
+{
+    if (m_state != TraceState::Tracing)
+    {
+        return absl::FailedPreconditionError(
+            absl::StrFormat("Can only check TraceShouldEnd() when TraceManger is Tracing, not "
+                            "TraceState: %s. Try ResetTrace()",
+                            TraceState2Str(m_state)));
+    }
+
+    if (!m_curr_trace_settings.has_value())
+    {
+        return absl::FailedPreconditionError(
+            "m_curr_trace_settings cannot be empty when the state is Tracing");
+    }
+
+    switch (m_curr_trace_settings->mode)
+    {
+        case TraceMode::Frame:
+        {
+            size_t desired_frames =
+                std::get<TraceByFrameConfig>(m_curr_trace_settings->config).total_frames;
+            if (m_application_frames - m_curr_trace_settings->trace_started_frame >= desired_frames)
+            {
+                return true;
+            }
+            return false;
+        }
+        case TraceMode::Duration:
+        {
+            absl::Duration desired_duration =
+                std::get<TraceByDurationConfig>(m_curr_trace_settings->config).trace_duration;
+            if (absl::Now() - m_curr_trace_settings->trace_started_time >= desired_duration)
+            {
+                return true;
+            }
+            return false;
+        }
+        default:
+        {
+            return absl::FailedPreconditionError(absl::StrFormat(
+                "Unrecognized current TraceMode: %s", TraceMode2Str(m_curr_trace_settings->mode)));
+        }
+    }
+}
+
+absl::Status CaptureManager::ProcessState() ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock)
+{
+    switch (m_state)
+    {
+        case TraceState::Triggered:
+        {
+            TraceSettings trace_settings;
+            trace_settings.mode = m_mode;
+            trace_settings.session_frame_index = m_traces_this_session;
+            switch (trace_settings.mode)
+            {
+                case TraceMode::Duration:
+                {
+                    trace_settings.config = m_duration_config;
+                    break;
+                }
+                case TraceMode::Frame:
+                {
+                    trace_settings.config = m_frame_config;
+                    break;
+                }
+                default:
+                {
+                    m_state = TraceState::Unknown;
+                    return absl::FailedPreconditionError(absl::StrFormat(
+                        "Invalid TraceMode: %s", TraceMode2Str(trace_settings.mode)));
+                }
+            }
+            trace_settings.trace_started_time = absl::Now();
+            trace_settings.trace_started_frame = m_application_frames;
+
+            if (absl::Status res = FromTriggeredToTracing(trace_settings); !res.ok())
+            {
+                m_state = TraceState::Unknown;
+                return res;
+            }
+            m_curr_trace_settings = trace_settings;
+            m_state = TraceState::Tracing;
+
+            break;
+        }
+        case TraceState::Tracing:
+        {
+            absl::StatusOr<bool> should_end = TraceShouldEnd();
+            if (!should_end.ok())
+            {
+                return should_end.status();
+            }
+
+            if (*should_end)
+            {
+                if (absl::Status res = FromTracingToFinished(); !res.ok())
+                {
+                    m_state = TraceState::Unknown;
+                    return res;
+                }
+                m_state = TraceState::Finished;
+            }
+
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+    return absl::OkStatus();
+}
+
+}  // namespace Dive

--- a/capture_service/capture_mgr.h
+++ b/capture_service/capture_mgr.h
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+
+namespace Dive
+{
+
+// CaptureManager is an abstract class, defining a Finite State Machine (FSM) that will switch
+// between different TraceStates. The TraceMode of the current trace may affect the transitioning
+// behaviour.
+class CaptureManager
+{
+ public:
+    enum class TraceState
+    {
+        Unknown = 0,
+        Idle = 1,       // CaptureManager is ready to start a new trace
+        Triggered = 2,  // A trace has been requested via TriggerTrace()
+        Tracing = 3,    // The trace is ongoing
+        Finished = 4,   // The trace has finished and the result must be retrieved with
+                        // GetFinishedTrace()
+    };
+
+    static std::string TraceState2Str(TraceState state);
+
+    enum class TraceMode
+    {
+        Unknown = 0,
+        Duration = 1,  // Captures for a specified duration after the trigger
+        Frame = 2,     // Captures for a specified number of frames after the trigger
+    };
+
+    static std::string TraceMode2Str(TraceMode mode);
+
+    struct TraceByFrameConfig
+    {
+        uint32_t total_frames = 1;
+    };
+
+    struct TraceByDurationConfig
+    {
+        absl::Duration trace_duration = absl::Seconds(3);
+    };
+
+    struct TraceSettings
+    {
+        TraceMode mode = TraceMode::Unknown;
+        std::variant<std::monostate, TraceByFrameConfig, TraceByDurationConfig> config;
+        absl::Time trace_started_time;
+        size_t trace_started_frame = 0;
+        size_t session_frame_index = 0;
+    };
+
+    struct TraceResult
+    {
+        // Not using std::filepath since the path delimiter of the device could differ from the host
+        std::string file_path = "";
+    };
+
+    // ------------------------------------------------------------------------
+    // Called once-per-frame by applications that are using the Dive layer to communicate with
+    // CaptureManager. Calling this will set the CaptureManager's mode to Frame until the next
+    // ResetAppSession()
+    void OnNewFrame() ABSL_LOCKS_EXCLUDED(m_state_lock);
+
+    // ------------------------------------------------------------------------
+    // Non-blocking, so it should be polled until the return value is error or true, then the
+    // finished trace can be checked with GetFinishedTracePath()
+    absl::StatusOr<bool> IsTraceFinished() ABSL_LOCKS_EXCLUDED(m_state_lock);
+
+    // ------------------------------------------------------------------------
+    // Communication that can be independent of the application's frame loop
+
+    // Indicate to CaptureManager to start a trace, either immediately or at the next OnNewFrame()
+    absl::Status TriggerTrace() ABSL_LOCKS_EXCLUDED(m_state_lock);
+
+    // Return a Finished trace's on-device path and set the state to Idle
+    absl::StatusOr<std::string> GetFinishedTracePath() ABSL_LOCKS_EXCLUDED(m_state_lock);
+
+    void ResetTrace() ABSL_LOCKS_EXCLUDED(m_state_lock);
+    void ResetAppSession() ABSL_LOCKS_EXCLUDED(m_state_lock);
+    void SetFrameConfig(const TraceByFrameConfig config);
+    void SetDurationConfig(const TraceByDurationConfig config);
+
+    // Exposed for testing
+    bool IsState(TraceState state) ABSL_LOCKS_EXCLUDED(m_state_lock);
+    size_t GetApplicationFrames() const { return m_application_frames; };
+
+ protected:
+    // These need to be defined by the derived class to communicate with the device to perform the
+    // trace
+    virtual absl::Status FromTriggeredToTracing(const TraceSettings& trace_settings) = 0;
+    virtual absl::Status FromTracingToFinished() = 0;
+    virtual absl::StatusOr<TraceResult> FromFinishedToIdle() = 0;
+
+ private:
+    absl::StatusOr<bool> TraceShouldEnd() ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock);
+    absl::Status ProcessState() ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_state_lock);
+
+    mutable absl::Mutex m_state_lock;
+    TraceState m_state ABSL_GUARDED_BY(m_state_lock) = TraceState::Idle;
+
+    // Empty when state is Idle
+    std::optional<TraceSettings> m_curr_trace_settings ABSL_GUARDED_BY(m_state_lock) = std::nullopt;
+
+    // CaptureManager holds multiple mode configs, but only one of these will be snapshotted and
+    // used to populate m_curr_trace_settings
+    TraceByFrameConfig m_frame_config = {};
+    TraceByDurationConfig m_duration_config = {};
+
+    // The CaptureManager's mode cannot be set directly but it is intuited from the use of
+    // OnNewFrame()
+    TraceMode m_mode = TraceMode::Duration;
+
+    // Tracking the current application session
+    size_t m_application_frames = 0;
+    size_t m_traces_this_session = 0;
+};
+
+}  // namespace Dive


### PR DESCRIPTION
The intent is to eventually replace `TraceManager` and `AndroidTraceManager` in the task of creating a PM4 capture

- OLD:
  - `TraceManager` and `AndroidTraceManager` : 
    - Basically all of the implementation is together inside `AndroidTraceManager`, which would make it harder in the future if we wanted to target the Windows platform without repeating the same state transition logic
    - The division between the different types of capture or "modes" (Frame vs Duration) is harder to follow. For example `m_num_frame_to_trace` and `m_trace_duration` are similar, but that isn't immediately clear from the code structure when they're members of different classes.
    - For Duration mode, the trace manager puts a thread to sleep, which could be more problematic (and interferes with writing tests)
- NEW:
  - `CaptureManager` : 
    - FSM that is basically the control loop for the PM4 capture process
    - An abstract class, which communicates which parts need implementation for targeting unsupported platforms
    - Uses the enum `TraceMode` to draw a clear delineation between the different ways to define the start/end points of a capture
    - Uses `m_curr_trace_settings` to snapshot and separate an ongoing trace's settings from any changes to the default settings of the `CaptureManager`
  - `AndroidCaptureManager` : 
    - Interfacing with the Android device to execute the capture
    - Separated from the state transitioning logic
    - Holds the member for the on-device file path
  - Better support for testing and error logging